### PR TITLE
HUSH-4703: Add GCP integration resource

### DIFF
--- a/examples/data-sources/hush_gcp_integration/data-source.tf
+++ b/examples/data-sources/hush_gcp_integration/data-source.tf
@@ -1,0 +1,20 @@
+# Look up a GCP integration by ID
+data "hush_gcp_integration" "by_id" {
+  id = "integ-123456"
+}
+
+# Look up a GCP integration by name
+data "hush_gcp_integration" "by_name" {
+  name = "production-gcp"
+}
+
+# Output retrieved values
+output "integration_status" {
+  value       = data.hush_gcp_integration.by_name.status
+  description = "Current status of the GCP integration"
+}
+
+output "integration_projects" {
+  value       = data.hush_gcp_integration.by_name.project
+  description = "Projects configured in the GCP integration"
+}

--- a/examples/resources/hush_gcp_integration/resource.tf
+++ b/examples/resources/hush_gcp_integration/resource.tf
@@ -1,0 +1,46 @@
+# Create a GCP integration with specific projects and features
+resource "hush_gcp_integration" "example" {
+  name        = "production-gcp"
+  description = "GCP integration for production environment"
+
+  project {
+    project_id = "my-gcp-project-001"
+    enabled    = true
+  }
+
+  project {
+    project_id = "my-gcp-project-002"
+    enabled    = true
+  }
+
+  feature {
+    name    = "iam"
+    enabled = true
+  }
+
+  feature {
+    name    = "secret_manager"
+    enabled = true
+  }
+}
+
+# Output the onboarding script to run in GCP Cloud Shell
+output "onboarding_script" {
+  value       = hush_gcp_integration.example.onboarding_script
+  sensitive   = true
+  description = "Run this script in GCP Cloud Shell to set up IAM permissions"
+}
+
+# Output the integration status
+output "integration_status" {
+  value       = hush_gcp_integration.example.status
+  description = "Current status of the integration (pending or ok)"
+}
+
+# After running the onboarding script, complete the integration
+# by adding the service_account_email from the script output:
+#
+# resource "hush_gcp_integration" "example" {
+#   ...
+#   service_account_email = "hush-<integration-id>@my-gcp-project.iam.gserviceaccount.com"
+# }

--- a/internal/client/gcp_integration.go
+++ b/internal/client/gcp_integration.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const gcpIntegrationsEndpoint = "/v1/integrations/gcp"
+
+// GCPProject represents a GCP project in an integration
+type GCPProject struct {
+	ProjectID      string  `json:"project_id"`
+	Enabled        bool    `json:"enabled"`
+	DisplayName    *string `json:"display_name,omitempty"`
+	State          string  `json:"state,omitempty"`
+	OrganizationID *string `json:"organization_id,omitempty"`
+}
+
+// GCPFeature represents a feature in a GCP integration
+type GCPFeature struct {
+	Name         string  `json:"name"`
+	Enabled      bool    `json:"enabled"`
+	State        string  `json:"state,omitempty"`
+	StateMessage *string `json:"state_message,omitempty"`
+}
+
+// GCPIntegration represents a GCP integration response
+type GCPIntegration struct {
+	ID                  string       `json:"id,omitempty"`
+	Name                string       `json:"name"`
+	Description         string       `json:"description,omitempty"`
+	Status              string       `json:"status,omitempty"`
+	Type                string       `json:"type,omitempty"`
+	ServiceAccountEmail *string      `json:"service_account_email,omitempty"`
+	Projects            []GCPProject `json:"projects,omitempty"`
+	Features            []GCPFeature `json:"features,omitempty"`
+}
+
+// CreateGCPIntegrationInput represents the input for creating a GCP integration
+type CreateGCPIntegrationInput struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Projects    []GCPProjectInput `json:"projects,omitempty"`
+	Features    []GCPFeatureInput `json:"features,omitempty"`
+}
+
+// GCPProjectInput represents a project in create/update input
+type GCPProjectInput struct {
+	ProjectID string `json:"project_id"`
+	Enabled   bool   `json:"enabled"`
+}
+
+// GCPFeatureInput represents a feature in create/update input
+type GCPFeatureInput struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+// CompleteGCPIntegrationInput represents the input for completing a GCP integration
+type CompleteGCPIntegrationInput struct {
+	ServiceAccountEmail string `json:"service_account_email"`
+}
+
+// UpdateGCPIntegrationInput represents the input for updating a GCP integration
+type UpdateGCPIntegrationInput struct {
+	Name        *string            `json:"name,omitempty"`
+	Description *string            `json:"description,omitempty"`
+	Projects    *[]GCPProjectInput `json:"projects,omitempty"`
+	Features    *[]GCPFeatureInput `json:"features,omitempty"`
+}
+
+// GCPIntegrationListResponse represents the response from listing GCP integrations
+type GCPIntegrationListResponse struct {
+	Items      []GCPIntegration `json:"items"`
+	NextCursor *string          `json:"next_cursor"`
+	HasMore    bool             `json:"has_more"`
+}
+
+// CreateGCPIntegration creates a new GCP integration (status=pending)
+func CreateGCPIntegration(ctx context.Context, c *Client, input *CreateGCPIntegrationInput) (*GCPIntegration, error) {
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPost, gcpIntegrationsEndpoint, input, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// CompleteGCPIntegration completes a pending GCP integration by providing the service account email
+func CompleteGCPIntegration(ctx context.Context, c *Client, id string, input *CompleteGCPIntegrationInput) (*GCPIntegration, error) {
+	path := fmt.Sprintf("/v1/integrations/%s/gcp", id)
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// GetGCPIntegration retrieves a GCP integration by ID
+func GetGCPIntegration(ctx context.Context, c *Client, id string) (*GCPIntegration, error) {
+	path := fmt.Sprintf("/v1/integrations/%s/gcp", id)
+	var integ GCPIntegration
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &integ); err != nil {
+		return nil, err
+	}
+	return &integ, nil
+}
+
+// UpdateGCPIntegration updates a GCP integration
+func UpdateGCPIntegration(ctx context.Context, c *Client, id string, input *UpdateGCPIntegrationInput) (*GCPIntegration, error) {
+	path := fmt.Sprintf("/v1/integrations/%s/gcp", id)
+	var result GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteGCPIntegration deletes a GCP integration
+func DeleteGCPIntegration(ctx context.Context, c *Client, id string) error {
+	path := fmt.Sprintf("/v1/integrations/%s/gcp", id)
+	err := c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GetGCPIntegrationOnboardingScript retrieves the onboarding script for a GCP integration
+func GetGCPIntegrationOnboardingScript(ctx context.Context, c *Client, id string) (string, error) {
+	path := fmt.Sprintf("/v1/integrations/%s/gcp/onboarding_script", id)
+	var script string
+	// The onboarding script endpoint returns plain text, not JSON.
+	// We use doRequest with nil result and handle the response manually.
+	// Actually, we need a special approach since doRequest expects JSON.
+	// Use a raw string response wrapper.
+	if err := c.doRawRequest(ctx, http.MethodGet, path, nil, &script); err != nil {
+		return "", err
+	}
+	return script, nil
+}
+
+// GetGCPIntegrationsByName retrieves GCP integrations by name
+// Note: The API may return partial matches, so we filter for exact name matches
+func GetGCPIntegrationsByName(ctx context.Context, c *Client, name string) ([]GCPIntegration, error) {
+	encodedName := url.QueryEscape(name)
+	path := fmt.Sprintf("/v1/integrations?type=gcp&name=%s", encodedName)
+
+	var resp GCPIntegrationListResponse
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	// Filter for exact name matches since API may return partial matches
+	var exactMatches []GCPIntegration
+	for _, integ := range resp.Items {
+		if integ.Name == name {
+			exactMatches = append(exactMatches, integ)
+		}
+	}
+
+	return exactMatches, nil
+}

--- a/internal/provider/gcp_integration/common.go
+++ b/internal/provider/gcp_integration/common.go
@@ -1,0 +1,512 @@
+package gcp_integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+const (
+	idDesc                  = "The unique identifier of the GCP integration"
+	nameDesc                = "The name of the GCP integration"
+	descriptionDesc         = "The description of the GCP integration"
+	statusDesc              = "The current status of the GCP integration (pending, ok)"
+	typeDesc                = "The type of integration (always gcp)"
+	serviceAccountEmailDesc = "The GCP service account email used for the integration. Providing this will complete the integration setup."
+	onboardingScriptDesc    = "The generated onboarding shell script for setting up GCP IAM permissions"
+)
+
+var gcpProjectIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{4,28}[a-z0-9]$`)
+
+func GCPIntegrationResourceSchema() map[string]*schema.Schema {
+	s := GCPIntegrationDataSourceSchema()
+
+	s["id"] = &schema.Schema{
+		Description: idDesc,
+		Type:        schema.TypeString,
+		Computed:    true,
+	}
+	s["name"] = &schema.Schema{
+		Description: nameDesc,
+		Type:        schema.TypeString,
+		Required:    true,
+	}
+	s["description"] = &schema.Schema{
+		Description: descriptionDesc,
+		Type:        schema.TypeString,
+		Optional:    true,
+	}
+	s["service_account_email"] = &schema.Schema{
+		Description: serviceAccountEmailDesc,
+		Type:        schema.TypeString,
+		Optional:    true,
+	}
+
+	s["project"] = &schema.Schema{
+		Description: "GCP project to include in the integration",
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"project_id": {
+					Description: "The GCP project ID",
+					Type:        schema.TypeString,
+					Required:    true,
+					ValidateFunc: validation.StringMatch(
+						gcpProjectIDPattern,
+						"must be a valid GCP project ID (6-30 lowercase letters, digits, or hyphens, starting with a letter and ending with a letter or digit)",
+					),
+				},
+				"enabled": {
+					Description: "Whether this project is enabled for scanning",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     true,
+				},
+				"display_name": {
+					Description: "The display name of the GCP project (discovered after completion)",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"state": {
+					Description: "The state of the project (requested, ACTIVE)",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"organization_id": {
+					Description: "The GCP organization ID the project belongs to",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+			},
+		},
+	}
+
+	s["feature"] = &schema.Schema{
+		Description: "Feature to enable for the GCP integration",
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Description: "The feature name (iam, secret_manager, gcs_tf_state, artifact_registry)",
+					Type:        schema.TypeString,
+					Required:    true,
+					ValidateFunc: validation.StringInSlice([]string{
+						"iam",
+						"secret_manager",
+						"gcs_tf_state",
+						"artifact_registry",
+					}, false),
+				},
+				"enabled": {
+					Description: "Whether this feature is enabled",
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     true,
+				},
+				"state": {
+					Description: "The state of the feature (ok, disabled, insufficient_permissions, error)",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"state_message": {
+					Description: "Additional details about the feature state",
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+func GCPIntegrationDataSourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Description:   idDesc,
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"name"},
+		},
+		"name": {
+			Description:   nameDesc,
+			Type:          schema.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{"id"},
+		},
+		"description": {
+			Description: descriptionDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"status": {
+			Description: statusDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"type": {
+			Description: typeDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"service_account_email": {
+			Description: serviceAccountEmailDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"project": {
+			Description: "GCP projects in the integration",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"project_id": {
+						Description: "The GCP project ID",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"enabled": {
+						Description: "Whether this project is enabled for scanning",
+						Type:        schema.TypeBool,
+						Computed:    true,
+					},
+					"display_name": {
+						Description: "The display name of the GCP project",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"state": {
+						Description: "The state of the project",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"organization_id": {
+						Description: "The GCP organization ID",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+				},
+			},
+		},
+		"feature": {
+			Description: "Features in the GCP integration",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Description: "The feature name",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"enabled": {
+						Description: "Whether this feature is enabled",
+						Type:        schema.TypeBool,
+						Computed:    true,
+					},
+					"state": {
+						Description: "The state of the feature",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"state_message": {
+						Description: "Additional details about the feature state",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+				},
+			},
+		},
+		"onboarding_script": {
+			Description: onboardingScriptDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+			Sensitive:   true,
+		},
+	}
+}
+
+// Helper Functions
+
+// gcpIntegrationResourceRead is the read function for the resource, preserving user-configured values
+func gcpIntegrationResourceRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return gcpIntegrationReadInternal(ctx, d, m, false)
+}
+
+// gcpIntegrationRead is the read function for the data source, returning all server values
+func gcpIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return gcpIntegrationReadInternal(ctx, d, m, true)
+}
+
+func gcpIntegrationReadInternal(ctx context.Context, d *schema.ResourceData, m interface{}, isDataSource bool) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	var integ *client.GCPIntegration
+	var err error
+
+	if id := d.Id(); id != "" {
+		integ, err = client.GetGCPIntegration(ctx, c, id)
+		if err != nil {
+			// Handle 404 errors gracefully by removing from state
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			} else {
+				return diag.FromErr(err)
+			}
+		}
+	} else if id, exists := d.GetOk("id"); exists {
+		// Lookup by ID provided in configuration
+		integID := id.(string)
+		integ, err = client.GetGCPIntegration(ctx, c, integID)
+		if err != nil {
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				return diag.Errorf("no GCP integration found with ID: %s", integID)
+			} else {
+				return diag.FromErr(err)
+			}
+		}
+	} else if name, exists := d.GetOk("name"); exists {
+		// Lookup by name
+		integName := name.(string)
+		integrations, err := client.GetGCPIntegrationsByName(ctx, c, integName)
+		if err != nil {
+			return diag.FromErr(fmt.Errorf("failed to lookup GCP integration by name '%s': %w", integName, err))
+		}
+
+		switch len(integrations) {
+		case 0:
+			return diag.Errorf("no GCP integration found with name: %s", integName)
+		case 1:
+			integ = &integrations[0]
+		default:
+			return diag.Errorf("multiple GCP integrations found with name '%s'. Integration names must be unique. Consider using the integration ID instead for exact matching", integName)
+		}
+	} else {
+		return diag.Errorf("either 'id' or 'name' must be specified")
+	}
+
+	if d.Id() == "" {
+		d.SetId(integ.ID)
+	}
+
+	// Fetch onboarding script
+	script, err := client.GetGCPIntegrationOnboardingScript(ctx, c, integ.ID)
+	if err != nil {
+		// Non-fatal: log warning but don't fail the read
+		// The script may not be available in all states
+		errResponse, ok := err.(*client.APIError)
+		if !ok || errResponse.StatusCode != http.StatusNotFound {
+			return diag.FromErr(fmt.Errorf("failed to fetch onboarding script: %w", err))
+		}
+	} else {
+		if err := d.Set("onboarding_script", script); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set onboarding_script: %w", err))
+		}
+	}
+
+	if diags := setGCPIntegrationFields(d, integ, isDataSource); diags.HasError() {
+		return diags
+	}
+
+	return nil
+}
+
+func setGCPIntegrationFields(d *schema.ResourceData, integ *client.GCPIntegration, isDataSource bool) diag.Diagnostics {
+	fields := map[string]interface{}{
+		"name":        integ.Name,
+		"description": integ.Description,
+		"status":      integ.Status,
+		"type":        integ.Type,
+	}
+
+	for field, value := range fields {
+		if err := d.Set(field, value); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set %s: %w", field, err))
+		}
+	}
+
+	// Set service_account_email
+	if integ.ServiceAccountEmail != nil {
+		if err := d.Set("service_account_email", *integ.ServiceAccountEmail); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set service_account_email: %w", err))
+		}
+	}
+
+	// Set projects - for data sources, always set from server
+	// For resources, merge server response with user-configured projects
+	if integ.Projects != nil {
+		// Build lookup map from server response
+		serverProjects := make(map[string]client.GCPProject)
+		for _, p := range integ.Projects {
+			serverProjects[p.ProjectID] = p
+		}
+
+		// Get current configured projects from state
+		currentProjects := d.Get("project").([]interface{})
+		if isDataSource || len(currentProjects) == 0 {
+			// Data source or no user-configured projects - set all from server
+			projects := make([]map[string]interface{}, len(integ.Projects))
+			for i, p := range integ.Projects {
+				project := map[string]interface{}{
+					"project_id": p.ProjectID,
+					"enabled":    p.Enabled,
+					"state":      p.State,
+				}
+				if p.DisplayName != nil {
+					project["display_name"] = *p.DisplayName
+				} else {
+					project["display_name"] = ""
+				}
+				if p.OrganizationID != nil {
+					project["organization_id"] = *p.OrganizationID
+				} else {
+					project["organization_id"] = ""
+				}
+				projects[i] = project
+			}
+			if err := d.Set("project", projects); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to set project: %w", err))
+			}
+		} else {
+			// User configured projects - update computed fields only
+			projects := make([]map[string]interface{}, len(currentProjects))
+			for i, cp := range currentProjects {
+				cpMap := cp.(map[string]interface{})
+				projectID := cpMap["project_id"].(string)
+				project := map[string]interface{}{
+					"project_id": projectID,
+					"enabled":    cpMap["enabled"].(bool),
+				}
+				// Update computed fields from server if available
+				if sp, ok := serverProjects[projectID]; ok {
+					project["state"] = sp.State
+					if sp.DisplayName != nil {
+						project["display_name"] = *sp.DisplayName
+					} else {
+						project["display_name"] = ""
+					}
+					if sp.OrganizationID != nil {
+						project["organization_id"] = *sp.OrganizationID
+					} else {
+						project["organization_id"] = ""
+					}
+				}
+				projects[i] = project
+			}
+			if err := d.Set("project", projects); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to set project: %w", err))
+			}
+		}
+	}
+
+	// Set features - for data sources, always set from server
+	// For resources, merge server response with user-configured features
+	if integ.Features != nil {
+		// Build lookup map from server response
+		serverFeatures := make(map[string]client.GCPFeature)
+		for _, f := range integ.Features {
+			serverFeatures[f.Name] = f
+		}
+
+		// Get current configured features from state
+		currentFeatures := d.Get("feature").([]interface{})
+		if isDataSource || len(currentFeatures) == 0 {
+			// Data source or no user-configured features - set all from server
+			features := make([]map[string]interface{}, len(integ.Features))
+			for i, f := range integ.Features {
+				feature := map[string]interface{}{
+					"name":    f.Name,
+					"enabled": f.Enabled,
+					"state":   f.State,
+				}
+				if f.StateMessage != nil {
+					feature["state_message"] = *f.StateMessage
+				} else {
+					feature["state_message"] = ""
+				}
+				features[i] = feature
+			}
+			if err := d.Set("feature", features); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to set feature: %w", err))
+			}
+		} else {
+			// User configured features - update computed fields only
+			features := make([]map[string]interface{}, len(currentFeatures))
+			for i, cf := range currentFeatures {
+				cfMap := cf.(map[string]interface{})
+				featureName := cfMap["name"].(string)
+				feature := map[string]interface{}{
+					"name":    featureName,
+					"enabled": cfMap["enabled"].(bool),
+				}
+				// Update computed fields from server if available
+				if sf, ok := serverFeatures[featureName]; ok {
+					feature["state"] = sf.State
+					if sf.StateMessage != nil {
+						feature["state_message"] = *sf.StateMessage
+					} else {
+						feature["state_message"] = ""
+					}
+				}
+				features[i] = feature
+			}
+			if err := d.Set("feature", features); err != nil {
+				return diag.FromErr(fmt.Errorf("failed to set feature: %w", err))
+			}
+		}
+	}
+
+	return nil
+}
+
+// extractProjectInputs extracts project block data from the schema into client input structs
+func extractProjectInputs(d *schema.ResourceData) []client.GCPProjectInput {
+	if v, ok := d.GetOk("project"); ok {
+		projectList := v.([]interface{})
+		if len(projectList) > 0 {
+			projects := make([]client.GCPProjectInput, len(projectList))
+			for i, p := range projectList {
+				projectMap := p.(map[string]interface{})
+				projects[i] = client.GCPProjectInput{
+					ProjectID: projectMap["project_id"].(string),
+					Enabled:   projectMap["enabled"].(bool),
+				}
+			}
+			return projects
+		}
+	}
+	return nil
+}
+
+// extractFeatureInputs extracts feature block data from the schema into client input structs
+func extractFeatureInputs(d *schema.ResourceData) []client.GCPFeatureInput {
+	if v, ok := d.GetOk("feature"); ok {
+		featureList := v.([]interface{})
+		if len(featureList) > 0 {
+			features := make([]client.GCPFeatureInput, len(featureList))
+			for i, f := range featureList {
+				featureMap := f.(map[string]interface{})
+				features[i] = client.GCPFeatureInput{
+					Name:    featureMap["name"].(string),
+					Enabled: featureMap["enabled"].(bool),
+				}
+			}
+			return features
+		}
+	}
+	return nil
+}

--- a/internal/provider/gcp_integration/data_source.go
+++ b/internal/provider/gcp_integration/data_source.go
@@ -1,0 +1,16 @@
+package gcp_integration
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const dataSourceDescription = "GCP integration data source for reading Hush Security GCP integration information"
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		Description: dataSourceDescription,
+
+		ReadContext: gcpIntegrationRead,
+		Schema:      GCPIntegrationDataSourceSchema(),
+	}
+}

--- a/internal/provider/gcp_integration/gcp_integration_test.go
+++ b/internal/provider/gcp_integration/gcp_integration_test.go
@@ -1,0 +1,477 @@
+package gcp_integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+// testAccProvider is a test provider instance for acceptance tests
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"api_key_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HUSH_API_KEY_ID", nil),
+			},
+			"api_key_secret": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("HUSH_API_KEY_SECRET", nil),
+			},
+			"realm": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HUSH_REALM", nil),
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"hush_gcp_integration": Resource(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"hush_gcp_integration": DataSource(),
+		},
+		ConfigureContextFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	realm := strings.ToLower(d.Get("realm").(string))
+
+	var baseURL string
+	if devURL := os.Getenv("HUSH_DEV_BASE_URL"); devURL != "" {
+		baseURL = devURL
+	} else {
+		baseURL = fmt.Sprintf("https://api.%s.hush-security.com", realm)
+	}
+
+	c, err := client.NewClient(
+		ctx,
+		d.Get("api_key_id").(string),
+		d.Get("api_key_secret").(string),
+		baseURL,
+	)
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	return c, nil
+}
+
+var providerFactories = map[string]func() (*schema.Provider, error){
+	"hush": func() (*schema.Provider, error) {
+		return testAccProvider, nil
+	},
+}
+
+func testAccPreCheck(t *testing.T) {
+	if os.Getenv("HUSH_API_KEY_ID") == "" {
+		t.Fatalf("HUSH_API_KEY_ID env var must be set")
+	}
+	if os.Getenv("HUSH_API_KEY_SECRET") == "" {
+		t.Fatalf("HUSH_API_KEY_SECRET env var must be set")
+	}
+	if os.Getenv("HUSH_REALM") == "" {
+		t.Fatalf("HUSH_REALM env var must be set")
+	}
+}
+
+// --- Resource Tests ---
+
+func TestAccResourceGCPIntegration_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			// Create step
+			{
+				Config: testAccGCPIntegrationConfig_basic("test-gcp-integration", "test gcp integration description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttrSet(
+						"hush_gcp_integration.test", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "name", "test-gcp-integration",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "description", "test gcp integration description",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "status", "pending",
+					),
+				),
+			},
+			// Update step
+			{
+				Config: testAccGCPIntegrationConfig_basic("test-gcp-integration-updated", "updated gcp integration description"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttrSet(
+						"hush_gcp_integration.test", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "name", "test-gcp-integration-updated",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "description", "updated gcp integration description",
+					),
+				),
+			},
+			// Import step
+			{
+				ResourceName:            "hush_gcp_integration.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"onboarding_script", "feature", "project"},
+			},
+		},
+	})
+}
+
+func TestAccResourceGCPIntegration_withProjects(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			// Create with projects
+			{
+				Config: testAccGCPIntegrationConfig_withProjects("test-gcp-with-projects", "integration with projects", "my-gcp-project-01"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "name", "test-gcp-with-projects",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "project.0.project_id", "my-gcp-project-01",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "project.0.enabled", "true",
+					),
+				),
+			},
+			// Import step
+			{
+				ResourceName:            "hush_gcp_integration.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"onboarding_script", "feature", "project"},
+			},
+		},
+	})
+}
+
+func TestAccResourceGCPIntegration_withFeatures(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			// Create with features
+			{
+				Config: testAccGCPIntegrationConfig_withFeatures("test-gcp-with-features", "integration with features"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "name", "test-gcp-with-features",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.0.name", "iam",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.0.enabled", "true",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.1.name", "secret_manager",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.1.enabled", "true",
+					),
+				),
+			},
+			// Import step
+			{
+				ResourceName:            "hush_gcp_integration.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"onboarding_script", "feature", "project"},
+			},
+		},
+	})
+}
+
+func TestAccResourceGCPIntegration_full(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			// Create with projects and features
+			{
+				Config: testAccGCPIntegrationConfig_full("test-gcp-full", "full integration", "my-gcp-project-01"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "name", "test-gcp-full",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "description", "full integration",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "project.0.project_id", "my-gcp-project-01",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.0.name", "iam",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.0.enabled", "true",
+					),
+				),
+			},
+			// Update - change description and add another feature
+			{
+				Config: testAccGCPIntegrationConfig_fullUpdated("test-gcp-full", "updated full integration", "my-gcp-project-01"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGCPIntegrationExists("hush_gcp_integration.test"),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "description", "updated full integration",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.0.name", "iam",
+					),
+					resource.TestCheckResourceAttr(
+						"hush_gcp_integration.test", "feature.1.name", "secret_manager",
+					),
+				),
+			},
+			// Import step
+			{
+				ResourceName:            "hush_gcp_integration.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"onboarding_script", "feature", "project"},
+			},
+		},
+	})
+}
+
+// --- Data Source Tests ---
+
+func TestAccDataSourceGCPIntegration_byID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGCPIntegrationConfig_basic("test-gcp-ds-id", "data source test by id") + testAccGCPIntegrationDataSourceConfig_byID,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.hush_gcp_integration.test", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.hush_gcp_integration.test", "name", "test-gcp-ds-id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.hush_gcp_integration.test", "description", "data source test by id",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceGCPIntegration_byName(t *testing.T) {
+	// Use a unique name to avoid collisions with stale test data
+	uniqueName := fmt.Sprintf("test-gcp-ds-name-%d", time.Now().UnixNano())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGCPIntegrationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGCPIntegrationConfig_basic(uniqueName, "data source test by name") + testAccGCPIntegrationDataSourceConfig_byName,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.hush_gcp_integration.test", "id",
+					),
+					resource.TestCheckResourceAttr(
+						"data.hush_gcp_integration.test", "name", uniqueName,
+					),
+					resource.TestCheckResourceAttr(
+						"data.hush_gcp_integration.test", "description", "data source test by name",
+					),
+				),
+			},
+		},
+	})
+}
+
+// --- Destroy and Exists check functions ---
+
+// testAccCheckGCPIntegrationDestroy verifies all GCP integration resources have been destroyed
+func testAccCheckGCPIntegrationDestroy(s *terraform.State) error {
+	c := testAccProvider.Meta().(*client.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "hush_gcp_integration" {
+			continue
+		}
+
+		_, err := client.GetGCPIntegration(context.Background(), c, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("GCP integration %s still exists", rs.Primary.ID)
+		}
+
+		apiError, ok := err.(*client.APIError)
+		if ok && apiError.IsNotFound() {
+			continue // Resource properly destroyed
+		}
+		return fmt.Errorf("failed to verify GCP integration %s was destroyed: %s", rs.Primary.ID, err)
+	}
+	return nil
+}
+
+// testAccCheckGCPIntegrationExists verifies a GCP integration resource exists in the API
+func testAccCheckGCPIntegrationExists(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set for resource: %s", resourceName)
+		}
+
+		c := testAccProvider.Meta().(*client.Client)
+
+		_, err := client.GetGCPIntegration(context.Background(), c, rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("GCP integration %s not found: %w", rs.Primary.ID, err)
+		}
+
+		return nil
+	}
+}
+
+// --- Test configuration helpers ---
+
+// testAccGCPIntegrationConfig_basic returns a basic GCP integration configuration
+func testAccGCPIntegrationConfig_basic(name, description string) string {
+	return fmt.Sprintf(`
+resource "hush_gcp_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+}
+`, name, description)
+}
+
+// testAccGCPIntegrationConfig_withProjects returns a GCP integration with a project
+func testAccGCPIntegrationConfig_withProjects(name, description, projectID string) string {
+	return fmt.Sprintf(`
+resource "hush_gcp_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  project {
+    project_id = %[3]q
+    enabled    = true
+  }
+}
+`, name, description, projectID)
+}
+
+// testAccGCPIntegrationConfig_withFeatures returns a GCP integration with features
+func testAccGCPIntegrationConfig_withFeatures(name, description string) string {
+	return fmt.Sprintf(`
+resource "hush_gcp_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  feature {
+    name    = "iam"
+    enabled = true
+  }
+
+  feature {
+    name    = "secret_manager"
+    enabled = true
+  }
+}
+`, name, description)
+}
+
+// testAccGCPIntegrationConfig_full returns a full GCP integration with projects and features
+func testAccGCPIntegrationConfig_full(name, description, projectID string) string {
+	return fmt.Sprintf(`
+resource "hush_gcp_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  project {
+    project_id = %[3]q
+    enabled    = true
+  }
+
+  feature {
+    name    = "iam"
+    enabled = true
+  }
+}
+`, name, description, projectID)
+}
+
+// testAccGCPIntegrationConfig_fullUpdated returns an updated full GCP integration
+func testAccGCPIntegrationConfig_fullUpdated(name, description, projectID string) string {
+	return fmt.Sprintf(`
+resource "hush_gcp_integration" "test" {
+  name        = %[1]q
+  description = %[2]q
+
+  project {
+    project_id = %[3]q
+    enabled    = true
+  }
+
+  feature {
+    name    = "iam"
+    enabled = true
+  }
+
+  feature {
+    name    = "secret_manager"
+    enabled = true
+  }
+}
+`, name, description, projectID)
+}
+
+// testAccGCPIntegrationDataSourceConfig_byID returns a data source configuration looking up by ID
+const testAccGCPIntegrationDataSourceConfig_byID = `
+data "hush_gcp_integration" "test" {
+  id = hush_gcp_integration.test.id
+}
+`
+
+// testAccGCPIntegrationDataSourceConfig_byName returns a data source configuration looking up by name
+const testAccGCPIntegrationDataSourceConfig_byName = `
+data "hush_gcp_integration" "test" {
+  name = hush_gcp_integration.test.name
+}
+`

--- a/internal/provider/gcp_integration/resource.go
+++ b/internal/provider/gcp_integration/resource.go
@@ -1,0 +1,151 @@
+package gcp_integration
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+const resourceDescription = "GCP integration resource for managing Hush Security GCP onboarding"
+
+func Resource() *schema.Resource {
+	return &schema.Resource{
+		Description: resourceDescription,
+
+		CreateContext: gcpIntegrationCreate,
+		ReadContext:   gcpIntegrationResourceRead,
+		UpdateContext: gcpIntegrationUpdate,
+		DeleteContext: gcpIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: GCPIntegrationResourceSchema(),
+	}
+}
+
+func gcpIntegrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	input := &client.CreateGCPIntegrationInput{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	// Extract projects
+	if projects := extractProjectInputs(d); projects != nil {
+		input.Projects = projects
+	}
+
+	// Extract features
+	if features := extractFeatureInputs(d); features != nil {
+		input.Features = features
+	}
+
+	// Step 1: Create integration (status=pending)
+	resp, err := client.CreateGCPIntegration(ctx, c, input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+
+	// Step 2: If service_account_email is provided, complete the integration
+	if saEmail, ok := d.GetOk("service_account_email"); ok {
+		email := saEmail.(string)
+		if email != "" {
+			completeInput := &client.CompleteGCPIntegrationInput{
+				ServiceAccountEmail: email,
+			}
+			_, err := client.CompleteGCPIntegration(ctx, c, resp.ID, completeInput)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	return gcpIntegrationResourceRead(ctx, d, m)
+}
+
+func gcpIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	input := &client.UpdateGCPIntegrationInput{}
+	hasChanges := false
+
+	if d.HasChange("name") {
+		name := d.Get("name").(string)
+		input.Name = &name
+		hasChanges = true
+	}
+	if d.HasChange("description") {
+		desc := d.Get("description").(string)
+		input.Description = &desc
+		hasChanges = true
+	}
+	if d.HasChange("project") {
+		projects := extractProjectInputs(d)
+		input.Projects = &projects
+		hasChanges = true
+	}
+	if d.HasChange("feature") {
+		features := extractFeatureInputs(d)
+		input.Features = &features
+		hasChanges = true
+	}
+
+	if hasChanges {
+		_, err := client.UpdateGCPIntegration(ctx, c, d.Id(), input)
+		if err != nil {
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+			return diag.FromErr(err)
+		}
+	}
+
+	// Handle service_account_email change: if changed and integration is pending, complete it
+	if d.HasChange("service_account_email") {
+		if saEmail, ok := d.GetOk("service_account_email"); ok {
+			email := saEmail.(string)
+			if email != "" {
+				// Check current status - only complete if pending
+				integ, err := client.GetGCPIntegration(ctx, c, d.Id())
+				if err != nil {
+					return diag.FromErr(err)
+				}
+				if integ.Status == "pending" {
+					completeInput := &client.CompleteGCPIntegrationInput{
+						ServiceAccountEmail: email,
+					}
+					_, err := client.CompleteGCPIntegration(ctx, c, d.Id(), completeInput)
+					if err != nil {
+						return diag.FromErr(err)
+					}
+				}
+			}
+		}
+	}
+
+	return gcpIntegrationResourceRead(ctx, d, m)
+}
+
+func gcpIntegrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	err := client.DeleteGCPIntegration(ctx, c, d.Id())
+	if err != nil {
+		errResponse, ok := err.(*client.APIError)
+		if ok && errResponse.StatusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
+	}
+	d.SetId("")
+	return nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hushsecurity/terraform-provider-hush/internal/client"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/access_policy"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/deployment"
+	"github.com/hushsecurity/terraform-provider-hush/internal/provider/gcp_integration"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/kv_access_credential"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/notification_channel"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/notification_configuration"
@@ -43,6 +44,7 @@ func New(version string) func() *schema.Provider {
 			},
 			ResourcesMap: map[string]*schema.Resource{
 				"hush_deployment":                  deployment.Resource(),
+				"hush_gcp_integration":             gcp_integration.Resource(),
 				"hush_notification_channel":        notification_channel.Resource(),
 				"hush_notification_configuration":  notification_configuration.Resource(),
 				"hush_plaintext_access_credential": plaintext_access_credential.Resource(),
@@ -51,6 +53,7 @@ func New(version string) func() *schema.Provider {
 			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"hush_deployment":                  deployment.DataSource(),
+				"hush_gcp_integration":             gcp_integration.DataSource(),
 				"hush_notification_channel":        notification_channel.DataSource(),
 				"hush_notification_configuration":  notification_configuration.DataSource(),
 				"hush_plaintext_access_credential": plaintext_access_credential.DataSource(),


### PR DESCRIPTION
Adds `hush_gcp_integration` resource and data source for managing GCP onboarding via Terraform.

**Changes:**
- Client methods for GCP integration CRUD + onboarding script retrieval
- Resource with two-phase creation (pending → completed via service account email)
- Data source with lookup by ID or name
- Acceptance tests and examples