### PR TITLE
HUSH-5360 Use latest patch toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hushsecurity/terraform-provider-hush
 
-go 1.25.0
+go 1.25.8
 
 require github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.0
 


### PR DESCRIPTION
1.25.0 is more than 6 month old. Use latest Go release with all security
fixes.
