### PR TITLE
HUSH-5677 aws_access_key: Add permission_boundary attribute

### DIFF
--- a/docs/data-sources/aws_access_key_access_credential.md
+++ b/docs/data-sources/aws_access_key_access_credential.md
@@ -32,4 +32,5 @@ data "hush_aws_access_key_access_credential" "example" {
 - `description` (String) The description of the AWS access key access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the AWS access key access credential
+- `permission_boundary` (Boolean) Whether the linked Access Privilege policy should be attached to the dynamically created IAM user as a permission boundary instead of as a managed policy. When enabled, the Access Privilege must contain exactly one policy.
 - `type` (String) The type of access credential

--- a/docs/resources/aws_access_key_access_credential.md
+++ b/docs/resources/aws_access_key_access_credential.md
@@ -37,6 +37,7 @@ resource "hush_aws_access_key_access_credential" "example" {
 
 - `access_key_id_value` (String) The AWS access key ID
 - `description` (String) The description of the AWS access key access credential
+- `permission_boundary` (Boolean) Whether the linked Access Privilege policy should be attached to the dynamically created IAM user as a permission boundary instead of as a managed policy. When enabled, the Access Privilege must contain exactly one policy.
 - `secret_access_key` (String, Sensitive) The AWS secret access key
 - `secret_access_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The AWS secret access key (write-only). This is a write-only attribute that is more secure than `secret_access_key` because Terraform will not store this value in the state file. Either `secret_access_key` or `secret_access_key_wo` must be specified.
 - `secret_access_key_wo_version` (String) Used to trigger updates for `secret_access_key_wo`. This value should be changed when the secret access key content changes. Can be any value (e.g., a timestamp, version number, or hash).

--- a/internal/client/dynamic_access_credential.go
+++ b/internal/client/dynamic_access_credential.go
@@ -1092,30 +1092,33 @@ func (a AzureAppAccessCredential) statusFields() (string, string) {
 // AWS Access Key
 
 type AWSAccessKeyAccessCredential struct {
-	ID            string               `json:"id,omitempty"`
-	Name          string               `json:"name"`
-	Description   string               `json:"description,omitempty"`
-	Type          AccessCredentialType `json:"type"`
-	Kind          string               `json:"kind,omitempty"`
-	DeploymentIDs []string             `json:"deployment_ids"`
-	AccessKeyID   string               `json:"access_key_id,omitempty"`
-	Status        string               `json:"status,omitempty"`
-	StatusDetail  string               `json:"status_detail,omitempty"`
+	ID                 string               `json:"id,omitempty"`
+	Name               string               `json:"name"`
+	Description        string               `json:"description,omitempty"`
+	Type               AccessCredentialType `json:"type"`
+	Kind               string               `json:"kind,omitempty"`
+	DeploymentIDs      []string             `json:"deployment_ids"`
+	AccessKeyID        string               `json:"access_key_id,omitempty"`
+	PermissionBoundary bool                 `json:"permission_boundary,omitempty"`
+	Status             string               `json:"status,omitempty"`
+	StatusDetail       string               `json:"status_detail,omitempty"`
 }
 
 type CreateAWSAccessKeyAccessCredentialInput struct {
-	Name            string   `json:"name"`
-	Description     string   `json:"description,omitempty"`
-	DeploymentIDs   []string `json:"deployment_ids"`
-	AccessKeyID     string   `json:"access_key_id"`
-	SecretAccessKey string   `json:"secret_access_key"`
+	Name               string   `json:"name"`
+	Description        string   `json:"description,omitempty"`
+	DeploymentIDs      []string `json:"deployment_ids"`
+	AccessKeyID        string   `json:"access_key_id"`
+	SecretAccessKey    string   `json:"secret_access_key"`
+	PermissionBoundary bool     `json:"permission_boundary,omitempty"`
 }
 
 type UpdateAWSAccessKeyAccessCredentialInput struct {
-	Name            *string `json:"name,omitempty"`
-	Description     *string `json:"description,omitempty"`
-	AccessKeyID     *string `json:"access_key_id,omitempty"`
-	SecretAccessKey *string `json:"secret_access_key,omitempty"`
+	Name               *string `json:"name,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	AccessKeyID        *string `json:"access_key_id,omitempty"`
+	SecretAccessKey    *string `json:"secret_access_key,omitempty"`
+	PermissionBoundary *bool   `json:"permission_boundary,omitempty"`
 }
 
 func CreateAWSAccessKeyAccessCredential(ctx context.Context, c *Client, input *CreateAWSAccessKeyAccessCredentialInput) (*AWSAccessKeyAccessCredential, error) {

--- a/internal/provider/aws_access_key_access_credential/common.go
+++ b/internal/provider/aws_access_key_access_credential/common.go
@@ -16,6 +16,7 @@ const (
 	secretAccessKeyDesc      = "The AWS secret access key"
 	secretAccessKeyWODesc    = "The AWS secret access key (write-only). This is a write-only attribute that is more secure than `secret_access_key` because Terraform will not store this value in the state file. Either `secret_access_key` or `secret_access_key_wo` must be specified."
 	secretAccessKeyWOVerDesc = "Used to trigger updates for `secret_access_key_wo`. This value should be changed when the secret access key content changes. Can be any value (e.g., a timestamp, version number, or hash)."
+	permissionBoundaryDesc   = "Whether the linked Access Privilege policy should be attached to the dynamically created IAM user as a permission boundary instead of as a managed policy. When enabled, the Access Privilege must contain exactly one policy."
 	typeDesc                 = "The type of access credential"
 	kindDesc                 = "The kind of access credential"
 )
@@ -79,6 +80,12 @@ func ResourceSchema() map[string]*schema.Schema {
 		Optional:     true,
 		RequiredWith: []string{"secret_access_key_wo"},
 	}
+	s["permission_boundary"] = &schema.Schema{
+		Description: permissionBoundaryDesc,
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+	}
 
 	return s
 }
@@ -111,6 +118,11 @@ func DataSourceSchema() map[string]*schema.Schema {
 		"access_key_id_value": {
 			Description: accessKeyIDValueDesc,
 			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"permission_boundary": {
+			Description: permissionBoundaryDesc,
+			Type:        schema.TypeBool,
 			Computed:    true,
 		},
 		"type": {

--- a/internal/provider/aws_access_key_access_credential/resource.go
+++ b/internal/provider/aws_access_key_access_credential/resource.go
@@ -49,11 +49,12 @@ func resourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	secretAccessKey := getSecretAccessKey(d)
 
 	input := &client.CreateAWSAccessKeyAccessCredentialInput{
-		Name:            d.Get("name").(string),
-		Description:     d.Get("description").(string),
-		DeploymentIDs:   deploymentIDs,
-		AccessKeyID:     d.Get("access_key_id_value").(string),
-		SecretAccessKey: secretAccessKey,
+		Name:               d.Get("name").(string),
+		Description:        d.Get("description").(string),
+		DeploymentIDs:      deploymentIDs,
+		AccessKeyID:        d.Get("access_key_id_value").(string),
+		SecretAccessKey:    secretAccessKey,
+		PermissionBoundary: d.Get("permission_boundary").(bool),
 	}
 
 	credential, err := client.CreateAWSAccessKeyAccessCredential(ctx, c, input)
@@ -96,6 +97,7 @@ func resourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Di
 		"description":         credential.Description,
 		"deployment_ids":      credential.DeploymentIDs,
 		"access_key_id_value": credential.AccessKeyID,
+		"permission_boundary": credential.PermissionBoundary,
 		"type":                string(credential.Type),
 		"kind":                credential.Kind,
 	}
@@ -130,6 +132,10 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	if d.HasChange("secret_access_key") || d.HasChange("secret_access_key_wo") || d.HasChange("secret_access_key_wo_version") {
 		secretAccessKey := getSecretAccessKey(d)
 		input.SecretAccessKey = &secretAccessKey
+	}
+	if d.HasChange("permission_boundary") {
+		v := d.Get("permission_boundary").(bool)
+		input.PermissionBoundary = &v
 	}
 
 	_, err := client.UpdateAWSAccessKeyAccessCredential(ctx, c, id, input)


### PR DESCRIPTION
Wires the new permission_boundary boolean through the AWS access key
dynamic credential resource: schema attribute (Optional, default false),
client request/response struct fields, and Create/Read/Update paths.
