### PR TITLE
HUSH-5723 github: add `id-token: write` permission in relase workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   goreleaser:


### PR DESCRIPTION
Required for `aws-actions/configure-aws-credentials`.
