### PR TITLE
HUSH-5723 github: setup TF in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
           go-version-file: "go.mod"
           cache: true
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.14.8"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:


### PR DESCRIPTION
This is needed for running unit tests with parallelism.

Otherwise tests fail (due to race) with the following error:

=== NAME  TestAccResourceMongoDBAccessCredential
    mongodb_access_credential_test.go:11: failed to create new working directory: unable to disable terraform-exec provider verification: fork/exec /tmp/plugintest-terraform2630751419/terraform: text file busy
--- FAIL: TestAccResourceMongoDBAccessCredential (2.77s)

`text file busy` error happens because one test tries to overwrite a
file that is currently being executed (terraform binary).
