### PR TITLE
HUSH-5937 provider: add access bridge wait for on-prem deployments

### DIFF
--- a/internal/client/deployment.go
+++ b/internal/client/deployment.go
@@ -107,3 +107,36 @@ func GetDeploymentsByName(ctx context.Context, c *Client, name string) ([]Deploy
 
 	return resp.Items, nil
 }
+
+// AccessBridgeStatus represents the response from the access_bridge endpoint
+type AccessBridgeStatus struct {
+	Status string `json:"status"`
+}
+
+const AccessBridgeStatusOk = "Ok"
+
+// GetAccessBridgeStatus retrieves the access bridge status for a deployment
+func GetAccessBridgeStatus(ctx context.Context, c *Client, deploymentID string) (*AccessBridgeStatus, error) {
+	path := fmt.Sprintf("%s/%s/access_bridge", deploymentsEndpoint, deploymentID)
+	var resp AccessBridgeStatus
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// WaitForAccessBridge polls the access bridge status until it becomes "Ok" or times out
+func WaitForAccessBridge(ctx context.Context, c *Client, deploymentID string) error {
+	return waitForStatus(ctx, func() (status, statusDetail string, err error) {
+		resp, err := GetAccessBridgeStatus(ctx, c, deploymentID)
+		if err != nil {
+			return "", "", err
+		}
+		// Map bridge status to the waitForStatus terminal states
+		if resp.Status == AccessBridgeStatusOk {
+			return "ok", "", nil
+		}
+		// Non-terminal: keep polling (e.g. "down", "disconnected")
+		return resp.Status, "", nil
+	})
+}

--- a/internal/provider/gitlab_integration/resource.go
+++ b/internal/provider/gitlab_integration/resource.go
@@ -74,6 +74,12 @@ func gitlabIntegrationCreate(ctx context.Context, d *schema.ResourceData, m any)
 
 	d.SetId(resp.ID)
 
+	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
+		if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
+			return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
+		}
+	}
+
 	return gitlabIntegrationRead(ctx, d, m)
 }
 
@@ -157,6 +163,14 @@ func gitlabIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m any)
 				return nil
 			}
 			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("onprem_deployment_id") {
+		if depID := d.Get("onprem_deployment_id").(string); depID != "" {
+			if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
+				return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds access bridge polling support for integration resources with `onprem_deployment_id`.

When an integration is created or updated with an `onprem_deployment_id`, the provider now polls `GET /v1/deployments/{id}/access_bridge` until the status becomes "Ok" (3-minute timeout, 10-second interval).

This ensures the deployment's access bridge is connected before the integration attempts to communicate through it.

**Changes:**
- `internal/client/deployment.go`: Add `GetAccessBridgeStatus` and `WaitForAccessBridge` functions
- `internal/provider/gitlab_integration/resource.go`: Call bridge wait after create/update when `onprem_deployment_id` is set

E2E tested against the dev API.