### PR TITLE
HUSH-5945 provider: add gcp_integration resource

### DIFF
--- a/examples/data-sources/hush_gcp_integration/data-source.tf
+++ b/examples/data-sources/hush_gcp_integration/data-source.tf
@@ -1,0 +1,3 @@
+data "hush_gcp_integration" "example" {
+  name = "my-gcp-integration"
+}

--- a/examples/resources/hush_gcp_integration/resource.tf
+++ b/examples/resources/hush_gcp_integration/resource.tf
@@ -1,0 +1,22 @@
+resource "hush_gcp_integration" "example" {
+  name        = "my-gcp-integration"
+  description = "GCP integration for scanning secrets"
+
+  features {
+    name    = "secret_manager"
+    enabled = true
+  }
+
+  features {
+    name    = "iam"
+    enabled = true
+  }
+
+  projects {
+    project_id = "my-gcp-project-123"
+    enabled    = true
+  }
+
+  # After running the onboarding script, uncomment to complete the integration:
+  # service_account_email = "hush-sa@my-gcp-project-123.iam.gserviceaccount.com"
+}

--- a/internal/client/gcp_integration.go
+++ b/internal/client/gcp_integration.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// GCP Integration
+
+type GCPProjectInput struct {
+	ProjectID string `json:"project_id"`
+	Enabled   bool   `json:"enabled"`
+}
+
+type GCPProject struct {
+	ProjectID      string `json:"project_id"`
+	DisplayName    string `json:"display_name,omitempty"`
+	State          string `json:"state,omitempty"`
+	StateMessage   string `json:"state_message,omitempty"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	Enabled        bool   `json:"enabled"`
+}
+
+type GCPFeatureInput struct {
+	Name    string `json:"name"`
+	Enabled bool   `json:"enabled"`
+}
+
+type GCPFeature struct {
+	Name         string `json:"name"`
+	Enabled      bool   `json:"enabled"`
+	State        string `json:"state,omitempty"`
+	StateMessage string `json:"state_message,omitempty"`
+}
+
+type GCPIntegration struct {
+	ID                    string       `json:"id,omitempty"`
+	Name                  string       `json:"name"`
+	Description           string       `json:"description,omitempty"`
+	Status                string       `json:"status,omitempty"`
+	StatusMessage         string       `json:"status_message,omitempty"`
+	StatusAt              string       `json:"status_at,omitempty"`
+	Type                  string       `json:"type,omitempty"`
+	OnpremDeploymentID    string       `json:"onprem_deployment_id,omitempty"`
+	ServiceAccountEmail   string       `json:"service_account_email,omitempty"`
+	Projects              []GCPProject `json:"projects,omitempty"`
+	Features              []GCPFeature `json:"features,omitempty"`
+	CreatedAt             string       `json:"created_at,omitempty"`
+	ModifiedAt            string       `json:"modified_at,omitempty"`
+	NextRescanAt          string       `json:"next_rescan_at,omitempty"`
+	NextFullScanAt        string       `json:"next_full_scan_at,omitempty"`
+	NextPeriodicChecksAt  string       `json:"next_periodic_checks_at,omitempty"`
+	NextUpdateResourcesAt string       `json:"next_update_resources_at,omitempty"`
+}
+
+type CreateGCPIntegrationInput struct {
+	Name               string            `json:"name"`
+	Description        string            `json:"description,omitempty"`
+	OnpremDeploymentID string            `json:"onprem_deployment_id,omitempty"`
+	Projects           []GCPProjectInput `json:"projects,omitempty"`
+	Features           []GCPFeatureInput `json:"features,omitempty"`
+}
+
+type UpdateGCPIntegrationInput struct {
+	Name               *string           `json:"name,omitempty"`
+	Description        *string           `json:"description,omitempty"`
+	OnpremDeploymentID *string           `json:"onprem_deployment_id,omitempty"`
+	Projects           []GCPProjectInput `json:"projects,omitempty"`
+	Features           []GCPFeatureInput `json:"features,omitempty"`
+}
+
+type CompleteGCPIntegrationInput struct {
+	ServiceAccountEmail string `json:"service_account_email"`
+}
+
+type GCPIntegrationListResponse struct {
+	Items        []GCPIntegration `json:"items"`
+	PageNumber   int              `json:"page_number"`
+	Total        *int             `json:"total"`
+	PreviousPage *string          `json:"previous_page"`
+	NextPage     *string          `json:"next_page"`
+}
+
+func CreateGCPIntegration(ctx context.Context, c *Client, input *CreateGCPIntegrationInput) (*GCPIntegration, error) {
+	path := fmt.Sprintf("%s/gcp", integrationsEndpoint)
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func GetGCPIntegration(ctx context.Context, c *Client, id string) (*GCPIntegration, error) {
+	path := fmt.Sprintf("%s/%s/gcp", integrationsEndpoint, id)
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func GetGCPIntegrationsByName(ctx context.Context, c *Client, name string) ([]GCPIntegration, error) {
+	encodedName := url.QueryEscape(name)
+	path := fmt.Sprintf("%s?name=%s&type=gcp", integrationsEndpoint, encodedName)
+	var resp GCPIntegrationListResponse
+	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Items, nil
+}
+
+func UpdateGCPIntegration(ctx context.Context, c *Client, id string, input *UpdateGCPIntegrationInput) (*GCPIntegration, error) {
+	path := fmt.Sprintf("%s/%s/gcp", integrationsEndpoint, id)
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPatch, path, input, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+func DeleteGCPIntegration(ctx context.Context, c *Client, id string) error {
+	// GCP uses type-specific delete endpoint
+	path := fmt.Sprintf("%s/%s/gcp", integrationsEndpoint, id)
+	return c.doRequest(ctx, http.MethodDelete, path, nil, nil)
+}
+
+func CompleteGCPIntegration(ctx context.Context, c *Client, id string, input *CompleteGCPIntegrationInput) (*GCPIntegration, error) {
+	path := fmt.Sprintf("%s/%s/gcp", integrationsEndpoint, id)
+	var resp GCPIntegration
+	if err := c.doRequest(ctx, http.MethodPost, path, input, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/internal/provider/gcp_integration/common.go
+++ b/internal/provider/gcp_integration/common.go
@@ -1,0 +1,411 @@
+package gcp_integration
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+const (
+	idDesc                    = "The unique identifier of the GCP integration"
+	nameDesc                  = "The name of the GCP integration"
+	descriptionDesc           = "The description of the GCP integration"
+	onpremDeploymentIDDesc    = "The ID of the on-premises deployment to associate with this integration"
+	serviceAccountEmailDesc   = "The GCP service account email from the onboarding script. Set this after running the onboarding script to complete the integration setup."
+	statusDesc                = "The current status of the integration"
+	statusMessageDesc         = "Additional details about the integration status"
+	statusAtDesc              = "The timestamp of the last status change"
+	typeDesc                  = "The type of integration (always 'gcp' for this resource)"
+	createdAtDesc             = "The timestamp when the integration was created"
+	modifiedAtDesc            = "The timestamp when the integration was last modified"
+	nextRescanAtDesc          = "The timestamp of the next scheduled rescan"
+	nextFullScanAtDesc        = "The timestamp of the next full scan"
+	nextPeriodicChecksAtDesc  = "The timestamp of the next periodic checks"
+	nextUpdateResourcesAtDesc = "The timestamp of the next resource update"
+	projectsDesc              = "List of GCP projects to scan"
+	projectIDDesc             = "The GCP project ID"
+	projectEnabledDesc        = "Whether scanning is enabled for this project"
+	projectDisplayNameDesc    = "The display name of the GCP project"
+	projectStateDesc          = "The current state of the project within the integration"
+	projectStateMessageDesc   = "Additional details about the project state"
+	projectOrganizationIDDesc = "The GCP organization ID associated with the project"
+	featuresDesc              = "List of GCP features to enable"
+	featureNameDesc           = "The feature name (secret_manager, gcs_tf_state, artifact_registry, iam)"
+	featureEnabledDesc        = "Whether this feature is enabled"
+	featureStateDesc          = "The current state of the feature"
+	featureStateMessageDesc   = "Additional details about the feature state"
+)
+
+var gcpFeatureNames = []string{"secret_manager", "gcs_tf_state", "artifact_registry", "iam"}
+
+func GCPIntegrationResourceSchema() map[string]*schema.Schema {
+	s := GCPIntegrationDataSourceSchema()
+
+	s["id"] = &schema.Schema{
+		Description: idDesc,
+		Type:        schema.TypeString,
+		Computed:    true,
+	}
+	s["name"] = &schema.Schema{
+		Description:  nameDesc,
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringLenBetween(1, 60),
+	}
+	s["description"] = &schema.Schema{
+		Description:  descriptionDesc,
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringLenBetween(0, 200),
+	}
+	s["onprem_deployment_id"] = &schema.Schema{
+		Description:  onpremDeploymentIDDesc,
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "onprem_deployment_id must start with 'dep-'"),
+	}
+	s["service_account_email"] = &schema.Schema{
+		Description: serviceAccountEmailDesc,
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+	}
+	s["projects"] = &schema.Schema{
+		Description: projectsDesc,
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"project_id": {
+					Description: projectIDDesc,
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"enabled": {
+					Description: projectEnabledDesc,
+					Type:        schema.TypeBool,
+					Required:    true,
+				},
+				"display_name": {
+					Description: projectDisplayNameDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"state": {
+					Description: projectStateDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"state_message": {
+					Description: projectStateMessageDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"organization_id": {
+					Description: projectOrganizationIDDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+			},
+		},
+	}
+	s["features"] = &schema.Schema{
+		Description: featuresDesc,
+		Type:        schema.TypeList,
+		Optional:    true,
+		Computed:    true,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Description:  featureNameDesc,
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice(gcpFeatureNames, false),
+				},
+				"enabled": {
+					Description: featureEnabledDesc,
+					Type:        schema.TypeBool,
+					Required:    true,
+				},
+				"state": {
+					Description: featureStateDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+				"state_message": {
+					Description: featureStateMessageDesc,
+					Type:        schema.TypeString,
+					Computed:    true,
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+func GCPIntegrationDataSourceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Description:   idDesc,
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"name"},
+		},
+		"name": {
+			Description:   nameDesc,
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"id"},
+		},
+		"description": {
+			Description: descriptionDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"onprem_deployment_id": {
+			Description: onpremDeploymentIDDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"service_account_email": {
+			Description: serviceAccountEmailDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"status": {
+			Description: statusDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"status_message": {
+			Description: statusMessageDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"status_at": {
+			Description: statusAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"type": {
+			Description: typeDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"created_at": {
+			Description: createdAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"modified_at": {
+			Description: modifiedAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"next_rescan_at": {
+			Description: nextRescanAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"next_full_scan_at": {
+			Description: nextFullScanAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"next_periodic_checks_at": {
+			Description: nextPeriodicChecksAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"next_update_resources_at": {
+			Description: nextUpdateResourcesAtDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"projects": {
+			Description: projectsDesc,
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"project_id": {
+						Description: projectIDDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"enabled": {
+						Description: projectEnabledDesc,
+						Type:        schema.TypeBool,
+						Computed:    true,
+					},
+					"display_name": {
+						Description: projectDisplayNameDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"state": {
+						Description: projectStateDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"state_message": {
+						Description: projectStateMessageDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"organization_id": {
+						Description: projectOrganizationIDDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+				},
+			},
+		},
+		"features": {
+			Description: featuresDesc,
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Description: featureNameDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"enabled": {
+						Description: featureEnabledDesc,
+						Type:        schema.TypeBool,
+						Computed:    true,
+					},
+					"state": {
+						Description: featureStateDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"state_message": {
+						Description: featureStateMessageDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func gcpIntegrationRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	var integration *client.GCPIntegration
+	var err error
+
+	if id := d.Id(); id != "" {
+		integration, err = client.GetGCPIntegration(ctx, c, id)
+		if err != nil {
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+			return diag.FromErr(err)
+		}
+	} else if id, exists := d.GetOk("id"); exists {
+		integrationID := id.(string)
+		integration, err = client.GetGCPIntegration(ctx, c, integrationID)
+		if err != nil {
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				return diag.Errorf("no GCP integration found with ID: %s", integrationID)
+			}
+			return diag.FromErr(err)
+		}
+	} else if name, exists := d.GetOk("name"); exists {
+		integrationName := name.(string)
+		integrations, lookupErr := client.GetGCPIntegrationsByName(ctx, c, integrationName)
+		if lookupErr != nil {
+			return diag.FromErr(fmt.Errorf("failed to lookup GCP integration by name '%s': %w", integrationName, lookupErr))
+		}
+		if len(integrations) == 0 {
+			return diag.Errorf("no GCP integration found with name: %s", integrationName)
+		}
+		if len(integrations) > 1 {
+			return diag.Errorf("multiple GCP integrations found with name: %s, please use id instead", integrationName)
+		}
+		// Get full details
+		integration, err = client.GetGCPIntegration(ctx, c, integrations[0].ID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	} else {
+		return diag.Errorf("one of `id` or `name` must be specified")
+	}
+
+	d.SetId(integration.ID)
+
+	fields := map[string]any{
+		"name":                     integration.Name,
+		"description":              integration.Description,
+		"onprem_deployment_id":     integration.OnpremDeploymentID,
+		"service_account_email":    integration.ServiceAccountEmail,
+		"status":                   integration.Status,
+		"status_message":           integration.StatusMessage,
+		"status_at":                integration.StatusAt,
+		"type":                     integration.Type,
+		"created_at":               integration.CreatedAt,
+		"modified_at":              integration.ModifiedAt,
+		"next_rescan_at":           integration.NextRescanAt,
+		"next_full_scan_at":        integration.NextFullScanAt,
+		"next_periodic_checks_at":  integration.NextPeriodicChecksAt,
+		"next_update_resources_at": integration.NextUpdateResourcesAt,
+	}
+
+	for field, value := range fields {
+		if err := d.Set(field, value); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set %s: %w", field, err))
+		}
+	}
+
+	if integration.Projects != nil {
+		projects := make([]map[string]any, len(integration.Projects))
+		for i, p := range integration.Projects {
+			projects[i] = map[string]any{
+				"project_id":      p.ProjectID,
+				"enabled":         p.Enabled,
+				"display_name":    p.DisplayName,
+				"state":           p.State,
+				"state_message":   p.StateMessage,
+				"organization_id": p.OrganizationID,
+			}
+		}
+		if err := d.Set("projects", projects); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set projects: %w", err))
+		}
+	}
+
+	if integration.Features != nil {
+		features := make([]map[string]any, len(integration.Features))
+		for i, f := range integration.Features {
+			features[i] = map[string]any{
+				"name":          f.Name,
+				"enabled":       f.Enabled,
+				"state":         f.State,
+				"state_message": f.StateMessage,
+			}
+		}
+		if err := d.Set("features", features); err != nil {
+			return diag.FromErr(fmt.Errorf("failed to set features: %w", err))
+		}
+	}
+
+	return nil
+}

--- a/internal/provider/gcp_integration/data.go
+++ b/internal/provider/gcp_integration/data.go
@@ -1,0 +1,16 @@
+package gcp_integration
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+const dataSourceDescription = "Use this data source to read information about an existing Hush Security GCP integration."
+
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		Description: dataSourceDescription,
+
+		ReadContext: gcpIntegrationRead,
+		Schema:      GCPIntegrationDataSourceSchema(),
+	}
+}

--- a/internal/provider/gcp_integration/resource.go
+++ b/internal/provider/gcp_integration/resource.go
@@ -1,0 +1,291 @@
+package gcp_integration
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+const resourceDescription = "Manages a Hush Security GCP integration for scanning GCP projects for secrets and sensitive data.\n\n" +
+	"GCP integrations use a two-phase onboarding flow:\n" +
+	"1. Create the integration (status will be PENDING)\n" +
+	"2. Run the onboarding script provided by Hush\n" +
+	"3. Set `service_account_email` and apply again to complete the integration"
+
+func Resource() *schema.Resource {
+	return &schema.Resource{
+		Description: resourceDescription,
+
+		CreateContext: gcpIntegrationCreate,
+		ReadContext:   gcpIntegrationResourceRead,
+		UpdateContext: gcpIntegrationUpdate,
+		DeleteContext: gcpIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: GCPIntegrationResourceSchema(),
+	}
+}
+
+func gcpIntegrationCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	input := &client.CreateGCPIntegrationInput{
+		Name: d.Get("name").(string),
+	}
+
+	if desc := d.Get("description").(string); desc != "" {
+		input.Description = desc
+	}
+	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
+		input.OnpremDeploymentID = depID
+	}
+
+	if v, ok := d.GetOk("projects"); ok {
+		input.Projects = expandGCPProjects(v.([]any))
+	}
+	if v, ok := d.GetOk("features"); ok {
+		input.Features = expandGCPFeatures(v.([]any))
+	}
+
+	resp, err := client.CreateGCPIntegration(ctx, c, input)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(resp.ID)
+
+	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
+		if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
+			return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
+		}
+	}
+
+	// If service_account_email is provided, complete the integration
+	if saEmail := d.Get("service_account_email").(string); saEmail != "" {
+		completeInput := &client.CompleteGCPIntegrationInput{
+			ServiceAccountEmail: saEmail,
+		}
+		_, err := client.CompleteGCPIntegration(ctx, c, d.Id(), completeInput)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	return gcpIntegrationResourceRead(ctx, d, m)
+}
+
+func gcpIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	// Handle completion if service_account_email is newly set
+	if d.HasChange("service_account_email") {
+		old, new := d.GetChange("service_account_email")
+		if old.(string) == "" && new.(string) != "" {
+			completeInput := &client.CompleteGCPIntegrationInput{
+				ServiceAccountEmail: new.(string),
+			}
+			_, err := client.CompleteGCPIntegration(ctx, c, d.Id(), completeInput)
+			if err != nil {
+				errResponse, ok := err.(*client.APIError)
+				if ok && errResponse.StatusCode == http.StatusNotFound {
+					d.SetId("")
+					return nil
+				}
+				return diag.FromErr(err)
+			}
+		}
+	}
+
+	// Handle metadata and nested block updates
+	input := &client.UpdateGCPIntegrationInput{}
+	hasChanges := false
+
+	if d.HasChange("name") {
+		name := d.Get("name").(string)
+		input.Name = &name
+		hasChanges = true
+	}
+	if d.HasChange("description") {
+		desc := d.Get("description").(string)
+		input.Description = &desc
+		hasChanges = true
+	}
+	if d.HasChange("onprem_deployment_id") {
+		depID := d.Get("onprem_deployment_id").(string)
+		input.OnpremDeploymentID = &depID
+		hasChanges = true
+	}
+	if d.HasChange("projects") {
+		if v, ok := d.GetOk("projects"); ok {
+			input.Projects = expandGCPProjects(v.([]any))
+		} else {
+			input.Projects = []client.GCPProjectInput{}
+		}
+		hasChanges = true
+	}
+	if d.HasChange("features") {
+		if v, ok := d.GetOk("features"); ok {
+			input.Features = expandGCPFeatures(v.([]any))
+		} else {
+			input.Features = []client.GCPFeatureInput{}
+		}
+		hasChanges = true
+	}
+
+	if hasChanges {
+		_, err := client.UpdateGCPIntegration(ctx, c, d.Id(), input)
+		if err != nil {
+			errResponse, ok := err.(*client.APIError)
+			if ok && errResponse.StatusCode == http.StatusNotFound {
+				d.SetId("")
+				return nil
+			}
+			return diag.FromErr(err)
+		}
+	}
+
+	if d.HasChange("onprem_deployment_id") {
+		if depID := d.Get("onprem_deployment_id").(string); depID != "" {
+			if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
+				return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
+			}
+		}
+	}
+
+	return gcpIntegrationResourceRead(ctx, d, m)
+}
+
+func gcpIntegrationDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	c := m.(*client.Client)
+
+	err := client.DeleteGCPIntegration(ctx, c, d.Id())
+	if err != nil {
+		errResponse, ok := err.(*client.APIError)
+		if ok && errResponse.StatusCode == http.StatusNotFound {
+			d.SetId("")
+		} else {
+			return diag.FromErr(err)
+		}
+	}
+	d.SetId("")
+	return nil
+}
+
+// gcpIntegrationResourceRead reads the integration and filters features/projects
+// to only include those the user configured, preventing drift from API defaults.
+func gcpIntegrationResourceRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	// Capture configured feature/project names BEFORE the read overwrites state
+	configuredFeatureNames := getConfiguredFeatureNames(d)
+	configuredProjectIDs := getConfiguredProjectIDs(d)
+
+	diags := gcpIntegrationRead(ctx, d, m)
+	if diags.HasError() || d.Id() == "" {
+		return diags
+	}
+
+	// Filter features to only those the user configured (API returns all, including disabled defaults)
+	if len(configuredFeatureNames) > 0 {
+		allFeatures := d.Get("features").([]any)
+		filtered := make([]map[string]any, 0, len(configuredFeatureNames))
+
+		// Preserve config ordering
+		for _, name := range configuredFeatureNames {
+			for _, af := range allFeatures {
+				afMap := af.(map[string]any)
+				if afMap["name"].(string) == name {
+					filtered = append(filtered, afMap)
+					break
+				}
+			}
+		}
+
+		if len(filtered) > 0 {
+			d.Set("features", filtered) //nolint:errcheck // already validated in gcpIntegrationRead
+		}
+	}
+
+	// Filter projects to only those the user configured
+	if len(configuredProjectIDs) > 0 {
+		allProjects := d.Get("projects").([]any)
+		filtered := make([]map[string]any, 0, len(configuredProjectIDs))
+
+		// Preserve config ordering
+		for _, pid := range configuredProjectIDs {
+			for _, ap := range allProjects {
+				apMap := ap.(map[string]any)
+				if apMap["project_id"].(string) == pid {
+					filtered = append(filtered, apMap)
+					break
+				}
+			}
+		}
+
+		if len(filtered) > 0 {
+			d.Set("projects", filtered) //nolint:errcheck // already validated in gcpIntegrationRead
+		}
+	}
+
+	return diags
+}
+
+// getConfiguredFeatureNames returns the feature names from the current state/config
+// before the read function overwrites them. On import (no prior state), returns nil.
+func getConfiguredFeatureNames(d *schema.ResourceData) []string {
+	raw := d.Get("features").([]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(raw))
+	for _, f := range raw {
+		m := f.(map[string]any)
+		if name, ok := m["name"].(string); ok && name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// getConfiguredProjectIDs returns the project IDs from the current state/config
+// before the read function overwrites them. On import (no prior state), returns nil.
+func getConfiguredProjectIDs(d *schema.ResourceData) []string {
+	raw := d.Get("projects").([]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(raw))
+	for _, p := range raw {
+		m := p.(map[string]any)
+		if pid, ok := m["project_id"].(string); ok && pid != "" {
+			ids = append(ids, pid)
+		}
+	}
+	return ids
+}
+
+func expandGCPProjects(raw []any) []client.GCPProjectInput {
+	projects := make([]client.GCPProjectInput, len(raw))
+	for i, v := range raw {
+		m := v.(map[string]any)
+		projects[i] = client.GCPProjectInput{
+			ProjectID: m["project_id"].(string),
+			Enabled:   m["enabled"].(bool),
+		}
+	}
+	return projects
+}
+
+func expandGCPFeatures(raw []any) []client.GCPFeatureInput {
+	features := make([]client.GCPFeatureInput, len(raw))
+	for i, v := range raw {
+		m := v.(map[string]any)
+		features[i] = client.GCPFeatureInput{
+			Name:    m["name"].(string),
+			Enabled: m["enabled"].(bool),
+		}
+	}
+	return features
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/deployment"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/elasticsearch_access_credential"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/elasticsearch_access_privilege"
+	"github.com/hushsecurity/terraform-provider-hush/internal/provider/gcp_integration"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/gcp_sa_access_credential"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/gcp_sa_access_privilege"
 	"github.com/hushsecurity/terraform-provider-hush/internal/provider/gcp_wif_access_credential"
@@ -137,6 +138,7 @@ func New(version string) func() *schema.Provider {
 				"hush_gitlab_integration":               gitlab_integration.Resource(),
 				"hush_confluence_integration":           confluence_integration.Resource(),
 				"hush_jira_integration":                 jira_integration.Resource(),
+				"hush_gcp_integration":                  gcp_integration.Resource(),
 				"hush_datadog_access_credential":        datadog_access_credential.Resource(),
 				"hush_datadog_access_privilege":         datadog_access_privilege.Resource(),
 				"hush_salesforce_access_credential":     salesforce_access_credential.Resource(),
@@ -189,6 +191,7 @@ func New(version string) func() *schema.Provider {
 				"hush_gitlab_integration":               gitlab_integration.DataSource(),
 				"hush_confluence_integration":           confluence_integration.DataSource(),
 				"hush_jira_integration":                 jira_integration.DataSource(),
+				"hush_gcp_integration":                  gcp_integration.DataSource(),
 				"hush_datadog_access_credential":        datadog_access_credential.DataSource(),
 				"hush_datadog_access_privilege":         datadog_access_privilege.DataSource(),
 				"hush_salesforce_access_credential":     salesforce_access_credential.DataSource(),


### PR DESCRIPTION
## Summary

Adds `hush_gcp_integration` resource and data source for managing GCP integrations via Terraform.

## Features
- Full CRUD support for GCP integrations
- Two-phase onboarding: create (PENDING) → run onboarding script → set `service_account_email` to complete
- Nested `features` block (secret_manager, gcs_tf_state, artifact_registry, iam)
- Nested `projects` block with computed state fields
- Type-specific delete endpoint (`DELETE /v1/integrations/{id}/gcp`)
- Data source supports lookup by ID or name
- Import via `terraform import`
- Filters API response to only persist user-configured features/projects (prevents drift)

## E2E Tested
- Create ✅
- Read (refresh) ✅
- Update (features) ✅
- Destroy ✅
- Data source (by ID) ✅
- No perpetual drift ✅

## Ticket
HUSH-5945