### PR TITLE
HUSH-5945 provider: remove onprem_deployment_id from confluence/jira and clean up computed fields

### DIFF
--- a/docs/data-sources/confluence_integration.md
+++ b/docs/data-sources/confluence_integration.md
@@ -38,13 +38,6 @@ output "confluence_status" {
 
 ### Read-Only
 
-- `created_at` (String) The timestamp when the integration was created
 - `description` (String) The description of the Confluence integration
-- `modified_at` (String) The timestamp when the integration was last modified
-- `next_rescan_at` (String) The timestamp of the next scheduled rescan
-- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 - `org_domain` (String) The Confluence organization domain (e.g., mycompany.atlassian.net)
 - `status` (String) The current status of the integration
-- `status_at` (String) The timestamp of the last status change
-- `status_message` (String) Additional details about the integration status
-- `type` (String) The type of integration (always 'confluence' for this resource)

--- a/docs/data-sources/gitlab_integration.md
+++ b/docs/data-sources/gitlab_integration.md
@@ -42,16 +42,12 @@ output "gitlab_integration_status" {
 
 - `base_url` (String) The base URL of the GitLab instance. Defaults to `https://gitlab.com`.
 - `bot_name` (String) The bot name used for GitLab integration (computed by the API)
-- `created_at` (String) The timestamp when the integration was created
 - `description` (String) The description of the GitLab integration
 - `enable_pr_scans` (Boolean) Whether to enable pull/merge request scanning for this integration
 - `group` (String) The resolved GitLab group name (computed)
 - `group_id` (Number) The GitLab group ID to scan. Mutually exclusive with `project_id`.
-- `modified_at` (String) The timestamp when the integration was last modified
 - `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 - `project_id` (Number) The GitLab project ID to scan. Mutually exclusive with `group_id`.
 - `selected_repos` (List of String) List of specific repository names to scan. If not specified, all repositories in the group/project are scanned.
 - `status` (String) The current status of the integration
-- `status_message` (String) Additional details about the integration status
-- `type` (String) The type of integration (always 'gitlab' for this resource)
 - `visibilities` (List of String) List of repository visibilities to scan. Valid values: `private`, `public`, `internal`.

--- a/docs/data-sources/jira_integration.md
+++ b/docs/data-sources/jira_integration.md
@@ -34,14 +34,9 @@ data "hush_jira_integration" "by_name" {
 
 ### Read-Only
 
-- `created_at` (String) The timestamp when the integration was created
 - `description` (String) The description of the Jira integration
 - `enable_scans` (Boolean) Whether to enable scanning of Jira issues. Defaults to `true`. Changing this forces a new resource.
-- `modified_at` (String) The timestamp when the integration was last modified
-- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 - `org_domain` (String) The Jira organization domain (e.g., mycompany.atlassian.net)
 - `status` (String) The current status of the integration
-- `status_message` (String) Additional details about the integration status
 - `sync_issues_resolution` (Boolean) Whether to sync issue resolution status from Jira. Defaults to `true`.
-- `type` (String) The type of integration (always 'jira' for this resource)
 - `webhook_provisioned` (Boolean) Whether the webhook has been provisioned for this integration

--- a/docs/resources/confluence_integration.md
+++ b/docs/resources/confluence_integration.md
@@ -48,15 +48,8 @@ resource "hush_confluence_integration" "secure" {
 - `api_key_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The API key for Confluence authentication (write-only). This is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified.
 - `api_key_wo_version` (String) Used to trigger updates for `api_key_wo`. This value should be changed when the API key changes. Can be any value (e.g., a timestamp, version number, or hash).
 - `description` (String) The description of the Confluence integration
-- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 
 ### Read-Only
 
-- `created_at` (String) The timestamp when the integration was created
 - `id` (String) The unique identifier of the Confluence integration
-- `modified_at` (String) The timestamp when the integration was last modified
-- `next_rescan_at` (String) The timestamp of the next scheduled rescan
 - `status` (String) The current status of the integration
-- `status_at` (String) The timestamp of the last status change
-- `status_message` (String) Additional details about the integration status
-- `type` (String) The type of integration (always 'confluence' for this resource)

--- a/docs/resources/gitlab_integration.md
+++ b/docs/resources/gitlab_integration.md
@@ -70,10 +70,6 @@ output "gitlab_integration_id" {
 ### Read-Only
 
 - `bot_name` (String) The bot name used for GitLab integration (computed by the API)
-- `created_at` (String) The timestamp when the integration was created
 - `group` (String) The resolved GitLab group name (computed)
 - `id` (String) The unique identifier of the GitLab integration
-- `modified_at` (String) The timestamp when the integration was last modified
 - `status` (String) The current status of the integration
-- `status_message` (String) Additional details about the integration status
-- `type` (String) The type of integration (always 'gitlab' for this resource)

--- a/docs/resources/jira_integration.md
+++ b/docs/resources/jira_integration.md
@@ -51,15 +51,10 @@ resource "hush_jira_integration" "full" {
 - `api_key_wo_version` (String) Used to trigger updates for `api_key_wo`. This value should be changed when the API key changes. Can be any value (e.g., a timestamp, version number, or hash).
 - `description` (String) The description of the Jira integration
 - `enable_scans` (Boolean) Whether to enable scanning of Jira issues. Defaults to `true`. Changing this forces a new resource.
-- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 - `sync_issues_resolution` (Boolean) Whether to sync issue resolution status from Jira. Defaults to `true`.
 
 ### Read-Only
 
-- `created_at` (String) The timestamp when the integration was created
 - `id` (String) The unique identifier of the Jira integration
-- `modified_at` (String) The timestamp when the integration was last modified
 - `status` (String) The current status of the integration
-- `status_message` (String) Additional details about the integration status
-- `type` (String) The type of integration (always 'jira' for this resource)
 - `webhook_provisioned` (Boolean) Whether the webhook has been provisioned for this integration

--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -143,18 +143,16 @@ type ConfluenceIntegration struct {
 }
 
 type CreateConfluenceIntegrationInput struct {
-	Name               string `json:"name"`
-	Description        string `json:"description,omitempty"`
-	OnpremDeploymentID string `json:"onprem_deployment_id,omitempty"`
-	OrgDomain          string `json:"org_domain"`
-	User               string `json:"user"`
-	ApiKey             string `json:"api_key"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	OrgDomain   string `json:"org_domain"`
+	User        string `json:"user"`
+	ApiKey      string `json:"api_key"`
 }
 
 type UpdateConfluenceIntegrationInput struct {
-	Name               *string `json:"name,omitempty"`
-	Description        *string `json:"description,omitempty"`
-	OnpremDeploymentID *string `json:"onprem_deployment_id,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 type ReplaceConfluenceApiKeyInput struct {
@@ -238,7 +236,6 @@ type JiraIntegration struct {
 type CreateJiraIntegrationInput struct {
 	Name                 string `json:"name"`
 	Description          string `json:"description,omitempty"`
-	OnpremDeploymentID   string `json:"onprem_deployment_id,omitempty"`
 	OrgDomain            string `json:"org_domain"`
 	User                 string `json:"user"`
 	ApiKey               string `json:"api_key"`
@@ -249,7 +246,6 @@ type CreateJiraIntegrationInput struct {
 type UpdateJiraIntegrationInput struct {
 	Name                 *string `json:"name,omitempty"`
 	Description          *string `json:"description,omitempty"`
-	OnpremDeploymentID   *string `json:"onprem_deployment_id,omitempty"`
 	OrgDomain            *string `json:"org_domain,omitempty"`
 	SyncIssuesResolution *bool   `json:"sync_issues_resolution,omitempty"`
 }

--- a/internal/provider/confluence_integration/common.go
+++ b/internal/provider/confluence_integration/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,22 +12,15 @@ import (
 )
 
 const (
-	idDesc                 = "The unique identifier of the Confluence integration"
-	nameDesc               = "The name of the Confluence integration"
-	descriptionDesc        = "The description of the Confluence integration"
-	orgDomainDesc          = "The Confluence organization domain (e.g., mycompany.atlassian.net)"
-	userDesc               = "The email address of the Confluence user for authentication"
-	apiKeyDesc             = "The API key for Confluence authentication"
-	apiKeyWODesc           = "The API key for Confluence authentication (write-only). This is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
-	apiKeyWOVersionDesc    = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key changes. Can be any value (e.g., a timestamp, version number, or hash)."
-	onpremDeploymentIDDesc = "The ID of the on-premises deployment to associate with this integration"
-	statusDesc             = "The current status of the integration"
-	statusMessageDesc      = "Additional details about the integration status"
-	statusAtDesc           = "The timestamp of the last status change"
-	typeDesc               = "The type of integration (always 'confluence' for this resource)"
-	createdAtDesc          = "The timestamp when the integration was created"
-	modifiedAtDesc         = "The timestamp when the integration was last modified"
-	nextRescanAtDesc       = "The timestamp of the next scheduled rescan"
+	idDesc              = "The unique identifier of the Confluence integration"
+	nameDesc            = "The name of the Confluence integration"
+	descriptionDesc     = "The description of the Confluence integration"
+	orgDomainDesc       = "The Confluence organization domain (e.g., mycompany.atlassian.net)"
+	userDesc            = "The email address of the Confluence user for authentication"
+	apiKeyDesc          = "The API key for Confluence authentication"
+	apiKeyWODesc        = "The API key for Confluence authentication (write-only). This is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
+	apiKeyWOVersionDesc = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key changes. Can be any value (e.g., a timestamp, version number, or hash)."
+	statusDesc          = "The current status of the integration"
 )
 
 func ConfluenceIntegrationResourceSchema() map[string]*schema.Schema {
@@ -86,13 +78,6 @@ func ConfluenceIntegrationResourceSchema() map[string]*schema.Schema {
 		Optional:     true,
 		RequiredWith: []string{"api_key_wo"},
 	}
-	s["onprem_deployment_id"] = &schema.Schema{
-		Description:  onpremDeploymentIDDesc,
-		Type:         schema.TypeString,
-		Optional:     true,
-		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "onprem_deployment_id must start with 'dep-'"),
-	}
-
 	return s
 }
 
@@ -122,43 +107,8 @@ func ConfluenceIntegrationDataSourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
-		"onprem_deployment_id": {
-			Description: onpremDeploymentIDDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
 		"status": {
 			Description: statusDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"status_message": {
-			Description: statusMessageDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"status_at": {
-			Description: statusAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"type": {
-			Description: typeDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"created_at": {
-			Description: createdAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"modified_at": {
-			Description: modifiedAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"next_rescan_at": {
-			Description: nextRescanAtDesc,
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
@@ -226,17 +176,10 @@ func confluenceIntegrationRead(ctx context.Context, d *schema.ResourceData, m an
 
 func setConfluenceIntegrationFields(d *schema.ResourceData, integration *client.ConfluenceIntegration) diag.Diagnostics {
 	fields := map[string]any{
-		"name":                 integration.Name,
-		"description":          integration.Description,
-		"org_domain":           integration.OrgDomain,
-		"onprem_deployment_id": integration.OnpremDeploymentID,
-		"status":               integration.Status,
-		"status_message":       integration.StatusMessage,
-		"status_at":            integration.StatusAt,
-		"type":                 integration.Type,
-		"created_at":           integration.CreatedAt,
-		"modified_at":          integration.ModifiedAt,
-		"next_rescan_at":       integration.NextRescanAt,
+		"name":        integration.Name,
+		"description": integration.Description,
+		"org_domain":  integration.OrgDomain,
+		"status":      integration.Status,
 	}
 
 	for field, value := range fields {

--- a/internal/provider/confluence_integration/resource.go
+++ b/internal/provider/confluence_integration/resource.go
@@ -44,9 +44,6 @@ func confluenceIntegrationCreate(ctx context.Context, d *schema.ResourceData, m 
 	if desc := d.Get("description").(string); desc != "" {
 		input.Description = desc
 	}
-	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-		input.OnpremDeploymentID = depID
-	}
 
 	resp, err := client.CreateConfluenceIntegration(ctx, c, input)
 	if err != nil {
@@ -54,12 +51,6 @@ func confluenceIntegrationCreate(ctx context.Context, d *schema.ResourceData, m 
 	}
 
 	d.SetId(resp.ID)
-
-	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-		if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
-			return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
-		}
-	}
 
 	return confluenceIntegrationRead(ctx, d, m)
 }
@@ -104,11 +95,6 @@ func confluenceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m 
 		input.Description = &desc
 		hasChanges = true
 	}
-	if d.HasChange("onprem_deployment_id") {
-		depID := d.Get("onprem_deployment_id").(string)
-		input.OnpremDeploymentID = &depID
-		hasChanges = true
-	}
 
 	if hasChanges {
 		_, err := client.UpdateConfluenceIntegration(ctx, c, d.Id(), input)
@@ -119,14 +105,6 @@ func confluenceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m 
 				return nil
 			}
 			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("onprem_deployment_id") {
-		if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-			if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
-				return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
-			}
 		}
 	}
 

--- a/internal/provider/gitlab_integration/common.go
+++ b/internal/provider/gitlab_integration/common.go
@@ -29,10 +29,6 @@ const (
 	botNameDesc            = "The bot name used for GitLab integration (computed by the API)"
 	onpremDeploymentIDDesc = "The ID of the on-premises deployment to associate with this integration"
 	statusDesc             = "The current status of the integration"
-	statusMessageDesc      = "Additional details about the integration status"
-	typeDesc               = "The type of integration (always 'gitlab' for this resource)"
-	createdAtDesc          = "The timestamp when the integration was created"
-	modifiedAtDesc         = "The timestamp when the integration was last modified"
 )
 
 func GitlabIntegrationResourceSchema() map[string]*schema.Schema {
@@ -211,26 +207,6 @@ func GitlabIntegrationDataSourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
-		"status_message": {
-			Description: statusMessageDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"type": {
-			Description: typeDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"created_at": {
-			Description: createdAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"modified_at": {
-			Description: modifiedAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
 	}
 }
 
@@ -303,10 +279,6 @@ func setGitlabIntegrationFields(d *schema.ResourceData, integration *client.Gitl
 		"bot_name":             integration.BotName,
 		"onprem_deployment_id": integration.OnpremDeploymentID,
 		"status":               integration.Status,
-		"status_message":       integration.StatusMessage,
-		"type":                 integration.Type,
-		"created_at":           integration.CreatedAt,
-		"modified_at":          integration.ModifiedAt,
 	}
 
 	if integration.EnablePRScans != nil {

--- a/internal/provider/jira_integration/common.go
+++ b/internal/provider/jira_integration/common.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,15 +20,10 @@ const (
 	apiKeyDesc               = "The API key for Jira authentication"
 	apiKeyWODesc             = "The API key for Jira authentication (write-only). This is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
 	apiKeyWOVersionDesc      = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key changes. Can be any value (e.g., a timestamp, version number, or hash)."
-	onpremDeploymentIDDesc   = "The ID of the on-premises deployment to associate with this integration"
 	syncIssuesResolutionDesc = "Whether to sync issue resolution status from Jira. Defaults to `true`."
 	enableScansDesc          = "Whether to enable scanning of Jira issues. Defaults to `true`. Changing this forces a new resource."
 	webhookProvisionedDesc   = "Whether the webhook has been provisioned for this integration"
 	statusDesc               = "The current status of the integration"
-	statusMessageDesc        = "Additional details about the integration status"
-	typeDesc                 = "The type of integration (always 'jira' for this resource)"
-	createdAtDesc            = "The timestamp when the integration was created"
-	modifiedAtDesc           = "The timestamp when the integration was last modified"
 )
 
 func JiraIntegrationResourceSchema() map[string]*schema.Schema {
@@ -86,12 +80,6 @@ func JiraIntegrationResourceSchema() map[string]*schema.Schema {
 		Optional:     true,
 		RequiredWith: []string{"api_key_wo"},
 	}
-	s["onprem_deployment_id"] = &schema.Schema{
-		Description:  onpremDeploymentIDDesc,
-		Type:         schema.TypeString,
-		Optional:     true,
-		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "onprem_deployment_id must start with 'dep-'"),
-	}
 	s["sync_issues_resolution"] = &schema.Schema{
 		Description: syncIssuesResolutionDesc,
 		Type:        schema.TypeBool,
@@ -135,11 +123,6 @@ func JiraIntegrationDataSourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
-		"onprem_deployment_id": {
-			Description: onpremDeploymentIDDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
 		"sync_issues_resolution": {
 			Description: syncIssuesResolutionDesc,
 			Type:        schema.TypeBool,
@@ -157,26 +140,6 @@ func JiraIntegrationDataSourceSchema() map[string]*schema.Schema {
 		},
 		"status": {
 			Description: statusDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"status_message": {
-			Description: statusMessageDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"type": {
-			Description: typeDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"created_at": {
-			Description: createdAtDesc,
-			Type:        schema.TypeString,
-			Computed:    true,
-		},
-		"modified_at": {
-			Description: modifiedAtDesc,
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
@@ -244,16 +207,11 @@ func jiraIntegrationRead(ctx context.Context, d *schema.ResourceData, m any) dia
 
 func setJiraIntegrationFields(d *schema.ResourceData, integration *client.JiraIntegration) diag.Diagnostics {
 	fields := map[string]any{
-		"name":                 integration.Name,
-		"description":          integration.Description,
-		"org_domain":           integration.OrgDomain,
-		"onprem_deployment_id": integration.OnpremDeploymentID,
-		"webhook_provisioned":  integration.WebhookProvisioned,
-		"status":               integration.Status,
-		"status_message":       integration.StatusMessage,
-		"type":                 integration.Type,
-		"created_at":           integration.CreatedAt,
-		"modified_at":          integration.ModifiedAt,
+		"name":                integration.Name,
+		"description":         integration.Description,
+		"org_domain":          integration.OrgDomain,
+		"webhook_provisioned": integration.WebhookProvisioned,
+		"status":              integration.Status,
 	}
 
 	for field, value := range fields {

--- a/internal/provider/jira_integration/resource.go
+++ b/internal/provider/jira_integration/resource.go
@@ -44,9 +44,6 @@ func jiraIntegrationCreate(ctx context.Context, d *schema.ResourceData, m any) d
 	if desc := d.Get("description").(string); desc != "" {
 		input.Description = desc
 	}
-	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-		input.OnpremDeploymentID = depID
-	}
 
 	syncIssues := d.Get("sync_issues_resolution").(bool)
 	input.SyncIssuesResolution = &syncIssues
@@ -60,12 +57,6 @@ func jiraIntegrationCreate(ctx context.Context, d *schema.ResourceData, m any) d
 	}
 
 	d.SetId(resp.ID)
-
-	if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-		if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
-			return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
-		}
-	}
 
 	return jiraIntegrationRead(ctx, d, m)
 }
@@ -110,11 +101,6 @@ func jiraIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m any) d
 		input.Description = &desc
 		hasChanges = true
 	}
-	if d.HasChange("onprem_deployment_id") {
-		depID := d.Get("onprem_deployment_id").(string)
-		input.OnpremDeploymentID = &depID
-		hasChanges = true
-	}
 	if d.HasChange("org_domain") {
 		orgDomain := d.Get("org_domain").(string)
 		input.OrgDomain = &orgDomain
@@ -135,14 +121,6 @@ func jiraIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m any) d
 				return nil
 			}
 			return diag.FromErr(err)
-		}
-	}
-
-	if d.HasChange("onprem_deployment_id") {
-		if depID := d.Get("onprem_deployment_id").(string); depID != "" {
-			if err := client.WaitForAccessBridge(ctx, c, depID); err != nil {
-				return diag.Errorf("error waiting for on-prem deployment %s to become available: %s", depID, err)
-			}
 		}
 	}
 


### PR DESCRIPTION
Remove `onprem_deployment_id` from Confluence and Jira integrations (not supported for these services) and remove unnecessary computed fields (`status_message`, `type`, `created_at`, `modified_at`, `status_at`, `next_rescan_at`) from all three integration resources. GitLab keeps `onprem_deployment_id` since it actually supports on-prem deployments. The `status` field is retained across all three as it's useful for monitoring integration health.