### PR TITLE
HUSH-5941 provider: add onprem_deployment_id to infisical_integration

### DIFF
--- a/docs/data-sources/infisical_integration.md
+++ b/docs/data-sources/infisical_integration.md
@@ -44,5 +44,6 @@ output "infisical_url" {
 
 - `base_url` (String) The Infisical base URL (e.g., https://app.infisical.com)
 - `description` (String) The description of the Infisical integration
+- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 - `status` (String) The current status of the integration
 - `status_message` (String) The status message providing additional details about the integration status

--- a/docs/resources/infisical_integration.md
+++ b/docs/resources/infisical_integration.md
@@ -57,6 +57,7 @@ resource "hush_infisical_integration" "with_description" {
 - `client_secret_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The client secret for Infisical authentication (write-only). This is more secure than `client_secret` because Terraform will not store this value in the state file. Either `client_secret` or `client_secret_wo` must be specified.
 - `client_secret_wo_version` (String) Used to trigger updates for `client_secret_wo`. This value should be changed when the client secret changes. Can be any value (e.g., a timestamp, version number, or hash).
 - `description` (String) The description of the Infisical integration
+- `onprem_deployment_id` (String) The ID of the on-premises deployment to associate with this integration
 
 ### Read-Only
 

--- a/internal/provider/infisical_integration/common.go
+++ b/internal/provider/infisical_integration/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,6 +21,7 @@ const (
 	clientSecretDesc          = "The client secret for Infisical authentication"
 	clientSecretWODesc        = "The client secret for Infisical authentication (write-only). This is more secure than `client_secret` because Terraform will not store this value in the state file. Either `client_secret` or `client_secret_wo` must be specified."
 	clientSecretWOVersionDesc = "Used to trigger updates for `client_secret_wo`. This value should be changed when the client secret changes. Can be any value (e.g., a timestamp, version number, or hash)."
+	onpremDeploymentIDDesc    = "The ID of the on-premises deployment to associate with this integration"
 	statusDesc                = "The current status of the integration"
 	statusMessageDesc         = "The status message providing additional details about the integration status"
 )
@@ -79,6 +81,12 @@ func InfisicalIntegrationResourceSchema() map[string]*schema.Schema {
 		Optional:     true,
 		RequiredWith: []string{"client_secret_wo"},
 	}
+	s["onprem_deployment_id"] = &schema.Schema{
+		Description:  onpremDeploymentIDDesc,
+		Type:         schema.TypeString,
+		Optional:     true,
+		ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "onprem_deployment_id must start with 'dep-'"),
+	}
 	return s
 }
 
@@ -105,6 +113,11 @@ func InfisicalIntegrationDataSourceSchema() map[string]*schema.Schema {
 		},
 		"base_url": {
 			Description: baseURLDesc,
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"onprem_deployment_id": {
+			Description: onpremDeploymentIDDesc,
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
@@ -182,11 +195,12 @@ func infisicalIntegrationRead(ctx context.Context, d *schema.ResourceData, m any
 
 func setInfisicalIntegrationFields(d *schema.ResourceData, integration *client.InfisicalIntegration) diag.Diagnostics {
 	fields := map[string]any{
-		"name":           integration.Name,
-		"description":    integration.Description,
-		"base_url":       integration.BaseURL,
-		"status":         integration.Status,
-		"status_message": integration.StatusMessage,
+		"name":                 integration.Name,
+		"description":          integration.Description,
+		"base_url":             integration.BaseURL,
+		"onprem_deployment_id": integration.OnpremDeploymentID,
+		"status":               integration.Status,
+		"status_message":       integration.StatusMessage,
 	}
 
 	for field, value := range fields {

--- a/internal/provider/infisical_integration/resource.go
+++ b/internal/provider/infisical_integration/resource.go
@@ -43,6 +43,10 @@ func infisicalIntegrationCreate(ctx context.Context, d *schema.ResourceData, m a
 		input.Description = desc
 	}
 
+	if onpremID := d.Get("onprem_deployment_id").(string); onpremID != "" {
+		input.OnpremDeploymentID = onpremID
+	}
+
 	resp, err := client.CreateInfisicalIntegration(ctx, c, input)
 	if err != nil {
 		return diag.FromErr(err)
@@ -93,6 +97,11 @@ func infisicalIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m a
 	if d.HasChange("base_url") {
 		baseURL := d.Get("base_url").(string)
 		input.BaseURL = &baseURL
+		hasChanges = true
+	}
+	if d.HasChange("onprem_deployment_id") {
+		onpremID := d.Get("onprem_deployment_id").(string)
+		input.OnpremDeploymentID = &onpremID
 		hasChanges = true
 	}
 


### PR DESCRIPTION
## HUSH-5941: Add onprem_deployment_id to Infisical Integration

### Summary
Adds `onprem_deployment_id` field to `hush_infisical_integration` resource and data source for on-premises deployment support.

### Changes
- **Resource Schema**: Added `onprem_deployment_id` as Optional with `dep-` prefix validation
- **Data Source Schema**: Added `onprem_deployment_id` as Computed
- **Create**: Passes `onprem_deployment_id` to API when set
- **Update**: Supports updating `onprem_deployment_id`
- **Read**: Reads `onprem_deployment_id` from API response

### Testing
- [x] `make format` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] `make build` passes
