### PR TITLE
HUSH-6412 deployment: add oidc_provider for passwordless token exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.16.0] - 2026-06-24
+
+### Added
+
+* **Deployment OIDC**: optional `oidc_provider` block on `hush_deployment` for passwordless token exchange, letting the agent present a signed OIDC token (such as a Kubernetes service account token) instead of the deployment password
+
+```hcl
+resource "hush_deployment" "k8s" {
+  name = "prod-cluster"
+  kind = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+}
+```
+
 ## [1.15.0] - 2026-06-22
 
 ### Added

--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -49,4 +49,14 @@ output "status" {
 - `description` (String) The description of the deployment
 - `env_type` (String) The environment type for the deployment (dev, prod)
 - `kind` (String) The deployment kind (k8s, ecs, serverless)
+- `oidc_provider` (List of Object) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. (see [below for nested schema](#nestedatt--oidc_provider))
 - `status` (String) The current status of the deployment
+
+<a id="nestedatt--oidc_provider"></a>
+### Nested Schema for `oidc_provider`
+
+Read-Only:
+
+- `allowed_subjects` (List of String)
+- `audience` (String)
+- `issuer` (String)

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -20,6 +20,21 @@ resource "hush_deployment" "example" {
   kind        = "k8s"
 }
 
+# Deployment with OIDC configuration for passwordless token exchange. The agent
+# presents a signed OIDC token (e.g. a Kubernetes service account token) instead
+# of the deployment password.
+resource "hush_deployment" "oidc" {
+  name     = "oidc-deployment"
+  env_type = "prod"
+  kind     = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:hush-agent"]
+  }
+}
+
 output "deployment" {
   value = hush_deployment.example
 }
@@ -37,6 +52,7 @@ output "deployment" {
 
 - `description` (String) The description of the deployment
 - `env_type` (String) The environment type for the deployment (dev, prod)
+- `oidc_provider` (Block List, Max: 1) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. (see [below for nested schema](#nestedblock--oidc_provider))
 
 ### Read-Only
 
@@ -45,3 +61,15 @@ output "deployment" {
 - `password` (String, Sensitive) The deployment password for authentication
 - `status` (String) The current status of the deployment
 - `token` (String, Sensitive) The deployment token for authentication
+
+<a id="nestedblock--oidc_provider"></a>
+### Nested Schema for `oidc_provider`
+
+Required:
+
+- `audience` (String) The audience claim expected in presented OIDC assertions.
+- `issuer` (String) The OIDC issuer URL (must be HTTPS). Its OpenID configuration and JWKS are used to verify presented assertions.
+
+Optional:
+
+- `allowed_subjects` (List of String) Optional list of allowed subject claims. A trailing '*' acts as a prefix wildcard (for example 'system:serviceaccount:hush-security:*'). When omitted, any subject is accepted.

--- a/examples/resources/hush_deployment/resource.tf
+++ b/examples/resources/hush_deployment/resource.tf
@@ -5,6 +5,21 @@ resource "hush_deployment" "example" {
   kind        = "k8s"
 }
 
+# Deployment with OIDC configuration for passwordless token exchange. The agent
+# presents a signed OIDC token (e.g. a Kubernetes service account token) instead
+# of the deployment password.
+resource "hush_deployment" "oidc" {
+  name     = "oidc-deployment"
+  env_type = "prod"
+  kind     = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:hush-agent"]
+  }
+}
+
 output "deployment" {
   value = hush_deployment.example
 }

--- a/internal/client/deployment.go
+++ b/internal/client/deployment.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,29 +10,60 @@ import (
 
 const deploymentsEndpoint = "/v1/deployments"
 
+// OidcConfig configures passwordless deployment token exchange via OIDC.
+type OidcConfig struct {
+	Issuer          string   `json:"issuer"`
+	Audience        string   `json:"audience"`
+	AllowedSubjects []string `json:"allowed_subjects,omitempty"`
+}
+
 type Deployment struct {
-	ID          string `json:"id,omitempty"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	EnvType     string `json:"env_type"`
-	Status      string `json:"status,omitempty"`
-	Kind        string `json:"kind,omitempty"`
+	ID           string      `json:"id,omitempty"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	EnvType      string      `json:"env_type"`
+	Status       string      `json:"status,omitempty"`
+	Kind         string      `json:"kind,omitempty"`
+	OidcProvider *OidcConfig `json:"oidc_provider,omitempty"`
 }
 
 // CreateDeploymentInput represents the input for creating a deployment
 type CreateDeploymentInput struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	EnvType     string `json:"env_type"`
-	Kind        string `json:"kind,omitempty"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	EnvType      string      `json:"env_type"`
+	Kind         string      `json:"kind,omitempty"`
+	OidcProvider *OidcConfig `json:"oidc_provider,omitempty"`
 }
 
-// UpdateDeploymentInput represents the input for updating a deployment
+// UpdateDeploymentInput represents the input for updating a deployment. Each
+// scalar is a pointer with omitempty so only changed fields are sent. The
+// oidc_provider field needs three states -- omitted (unchanged), set, and
+// explicit null (removed) -- which omitempty alone cannot express, so it uses
+// the oidcProviderUpdate wrapper.
 type UpdateDeploymentInput struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	EnvType     *string `json:"env_type,omitempty"`
-	Kind        *string `json:"kind,omitempty"`
+	Name         *string             `json:"name,omitempty"`
+	Description  *string             `json:"description,omitempty"`
+	EnvType      *string             `json:"env_type,omitempty"`
+	Kind         *string             `json:"kind,omitempty"`
+	OidcProvider *oidcProviderUpdate `json:"oidc_provider,omitempty"`
+}
+
+// oidcProviderUpdate marshals to null when Config is nil (removal) and to the
+// config object otherwise. A nil wrapper on the input is omitted (no change).
+type oidcProviderUpdate struct{ Config *OidcConfig }
+
+func (o oidcProviderUpdate) MarshalJSON() ([]byte, error) {
+	if o.Config == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(o.Config)
+}
+
+// NewOidcProviderUpdate wraps an OIDC config (possibly nil for removal) for an
+// update request, forcing the oidc_provider field to be sent.
+func NewOidcProviderUpdate(config *OidcConfig) *oidcProviderUpdate {
+	return &oidcProviderUpdate{Config: config}
 }
 
 // DeploymentCredentialsResponse embeds Deployment and adds credentials

--- a/internal/client/deployment_test.go
+++ b/internal/client/deployment_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestUpdateDeploymentInput_OidcProviderMarshaling verifies the three update
+// states of oidc_provider: omitted when unchanged, explicit null when removed,
+// and the config object when set.
+func TestUpdateDeploymentInput_OidcProviderMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    UpdateDeploymentInput
+		contains string
+		omits    bool
+	}{
+		{
+			name:  "unchanged omits the field",
+			input: UpdateDeploymentInput{},
+			omits: true,
+		},
+		{
+			name:     "removal sends explicit null",
+			input:    UpdateDeploymentInput{OidcProvider: NewOidcProviderUpdate(nil)},
+			contains: `"oidc_provider":null`,
+		},
+		{
+			name: "set sends the config object",
+			input: UpdateDeploymentInput{OidcProvider: NewOidcProviderUpdate(&OidcConfig{
+				Issuer:          "https://issuer.example.com",
+				Audience:        "hush",
+				AllowedSubjects: []string{"system:serviceaccount:hush:*"},
+			})},
+			contains: `"oidc_provider":{"issuer":"https://issuer.example.com","audience":"hush","allowed_subjects":["system:serviceaccount:hush:*"]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			got := string(b)
+			if tc.omits {
+				if strings.Contains(got, "oidc_provider") {
+					t.Fatalf("expected oidc_provider to be omitted, got %s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.contains) {
+				t.Fatalf("expected %s to contain %s", got, tc.contains)
+			}
+		})
+	}
+}

--- a/internal/provider/deployment/common.go
+++ b/internal/provider/deployment/common.go
@@ -21,6 +21,11 @@ const (
 	tokenDesc           = "The deployment token for authentication"
 	passwordDesc        = "The deployment password for authentication"
 	imagePullSecretDesc = "The image pull secret for accessing private container images"
+
+	oidcProviderDesc        = "Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password."
+	oidcIssuerDesc          = "The OIDC issuer URL (must be HTTPS). Its OpenID configuration and JWKS are used to verify presented assertions."
+	oidcAudienceDesc        = "The audience claim expected in presented OIDC assertions."
+	oidcAllowedSubjectsDesc = "Optional list of allowed subject claims. A trailing '*' acts as a prefix wildcard (for example 'system:serviceaccount:hush-security:*'). When omitted, any subject is accepted."
 )
 
 func DeploymentResourceSchema() map[string]*schema.Schema {
@@ -81,6 +86,34 @@ func DeploymentResourceSchema() map[string]*schema.Schema {
 		Sensitive:   true,
 	}
 
+	s["oidc_provider"] = &schema.Schema{
+		Description: oidcProviderDesc,
+		Type:        schema.TypeList,
+		Optional:    true,
+		MaxItems:    1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"issuer": {
+					Description:  oidcIssuerDesc,
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.IsURLWithHTTPS,
+				},
+				"audience": {
+					Description: oidcAudienceDesc,
+					Type:        schema.TypeString,
+					Required:    true,
+				},
+				"allowed_subjects": {
+					Description: oidcAllowedSubjectsDesc,
+					Type:        schema.TypeList,
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+				},
+			},
+		},
+	}
+
 	return s
 }
 
@@ -118,6 +151,31 @@ func DeploymentDataSourceSchema() map[string]*schema.Schema {
 			Description: statusDesc,
 			Type:        schema.TypeString,
 			Computed:    true,
+		},
+		"oidc_provider": {
+			Description: oidcProviderDesc,
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"issuer": {
+						Description: oidcIssuerDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"audience": {
+						Description: oidcAudienceDesc,
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"allowed_subjects": {
+						Description: oidcAllowedSubjectsDesc,
+						Type:        schema.TypeList,
+						Computed:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+					},
+				},
+			},
 		},
 	}
 }
@@ -200,5 +258,22 @@ func setDeploymentFields(d *schema.ResourceData, deployment *client.Deployment) 
 		}
 	}
 
+	if err := d.Set("oidc_provider", flattenOidcProvider(deployment.OidcProvider)); err != nil {
+		return diag.FromErr(fmt.Errorf("failed to set oidc_provider: %w", err))
+	}
+
 	return nil
+}
+
+// flattenOidcProvider converts the API OIDC config into the single-element list
+// the nested block schema expects, or an empty list when none is configured.
+func flattenOidcProvider(oidc *client.OidcConfig) []map[string]any {
+	if oidc == nil {
+		return []map[string]any{}
+	}
+	return []map[string]any{{
+		"issuer":           oidc.Issuer,
+		"audience":         oidc.Audience,
+		"allowed_subjects": oidc.AllowedSubjects,
+	}}
 }

--- a/internal/provider/deployment/deployment_test.go
+++ b/internal/provider/deployment/deployment_test.go
@@ -228,3 +228,81 @@ data "hush_deployment" "test" {
   id = hush_deployment.test.id
 }
 `
+
+const (
+	oidcTestIssuer   = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
+	oidcTestAudience = "https://kubernetes.default.svc"
+)
+
+// TestAccResourceDeployment_oidc exercises the full oidc_provider lifecycle:
+// create with the block, update it, remove it (explicit null to the API), and
+// import.
+func TestAccResourceDeployment_oidc(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckDeploymentDestroy,
+		Steps: []resource.TestStep{
+			// Create with oidc_provider
+			{
+				Config: testAccDeploymentConfig_oidc("test-oidc", oidcTestAudience, `["system:serviceaccount:hush-security:hush-agent"]`),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDeploymentExists("hush_deployment.test"),
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.#", "1"),
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.0.issuer", oidcTestIssuer),
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.0.audience", oidcTestAudience),
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.0.allowed_subjects.#", "1"),
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.0.allowed_subjects.0", "system:serviceaccount:hush-security:hush-agent"),
+				),
+			},
+			// Update the block (widen allowed subjects)
+			{
+				Config: testAccDeploymentConfig_oidc("test-oidc", oidcTestAudience, `["system:serviceaccount:hush-security:*", "system:serviceaccount:other:*"]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.0.allowed_subjects.#", "2"),
+				),
+			},
+			// Remove the block
+			{
+				Config: testAccDeploymentConfig_noOidc("test-oidc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.test", "oidc_provider.#", "0"),
+				),
+			},
+			// Import
+			{
+				ResourceName:      "hush_deployment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// testAccDeploymentConfig_oidc returns a deployment configuration with an
+// oidc_provider block. allowedSubjects is injected verbatim as an HCL list.
+func testAccDeploymentConfig_oidc(name, audience, allowedSubjects string) string {
+	return fmt.Sprintf(`
+resource "hush_deployment" "test" {
+  name = %[1]q
+  kind = "k8s"
+
+  oidc_provider {
+    issuer           = %[2]q
+    audience         = %[3]q
+    allowed_subjects = %[4]s
+  }
+}
+`, name, oidcTestIssuer, audience, allowedSubjects)
+}
+
+// testAccDeploymentConfig_noOidc returns a deployment configuration without an
+// oidc_provider block, used to verify removal.
+func testAccDeploymentConfig_noOidc(name string) string {
+	return fmt.Sprintf(`
+resource "hush_deployment" "test" {
+  name = %[1]q
+  kind = "k8s"
+}
+`, name)
+}

--- a/internal/provider/deployment/resource.go
+++ b/internal/provider/deployment/resource.go
@@ -31,10 +31,11 @@ func deploymentCreate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	c := m.(*client.Client)
 
 	input := &client.CreateDeploymentInput{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		EnvType:     d.Get("env_type").(string),
-		Kind:        d.Get("kind").(string),
+		Name:         d.Get("name").(string),
+		Description:  d.Get("description").(string),
+		EnvType:      d.Get("env_type").(string),
+		Kind:         d.Get("kind").(string),
+		OidcProvider: expandOidcProvider(d),
 	}
 
 	resp, err := client.CreateDeploymentWithCredentials(ctx, c, input)
@@ -43,6 +44,11 @@ func deploymentCreate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	}
 
 	d.SetId(resp.ID)
+
+	// Sync the returned deployment (including oidc_provider) into state.
+	if diags := setDeploymentFields(d, &resp.Deployment); diags.HasError() {
+		return diags
+	}
 
 	// Set computed sensitive fields
 	if err := d.Set("token", resp.Token); err != nil {
@@ -84,6 +90,10 @@ func deploymentUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 		input.Kind = &kind
 		hasChanges = true
 	}
+	if d.HasChange("oidc_provider") {
+		input.OidcProvider = client.NewOidcProviderUpdate(expandOidcProvider(d))
+		hasChanges = true
+	}
 
 	if !hasChanges {
 		return nil
@@ -100,6 +110,28 @@ func deploymentUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	}
 
 	return nil
+}
+
+// expandOidcProvider reads the oidc_provider block from configuration,
+// returning nil when the block is absent.
+func expandOidcProvider(d *schema.ResourceData) *client.OidcConfig {
+	raw := d.Get("oidc_provider").([]any)
+	if len(raw) == 0 || raw[0] == nil {
+		return nil
+	}
+	m := raw[0].(map[string]any)
+
+	cfg := &client.OidcConfig{
+		Issuer:   m["issuer"].(string),
+		Audience: m["audience"].(string),
+	}
+	if subs, ok := m["allowed_subjects"].([]any); ok && len(subs) > 0 {
+		cfg.AllowedSubjects = make([]string, len(subs))
+		for i, s := range subs {
+			cfg.AllowedSubjects[i] = s.(string)
+		}
+	}
+	return cfg
 }
 
 func deploymentDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {


### PR DESCRIPTION
## What

Add support for OIDC deployment configuration to `hush_deployment`. A deployment
carrying an `oidc_provider` config lets the agent exchange a signed OIDC token
(for example a Kubernetes service account token) for a deployment token instead
of using the long-lived password, so customers can now declare this as code.

## Changes

- **Resource**: optional `oidc_provider` block on `hush_deployment` with
  `issuer` (HTTPS, required), `audience` (required), and `allowed_subjects`
  (optional list; a trailing `*` is a prefix wildcard).
- **Data source**: `oidc_provider` exposed read-only.
- **Client**: `OidcConfig` wired into create and read. On update, the field is
  sent only when it changed -- the object on set, an explicit `null` on removal
  -- so deleting the block clears it server-side without leaving a perpetual
  diff, and unrelated updates leave it untouched.
- Docs regenerated, example extended, CHANGELOG `1.16.0` entry added.
