### PR TITLE
HUSH-6412 docs: use wildcard subject in deployment oidc example

### DIFF
--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -31,7 +31,7 @@ resource "hush_deployment" "oidc" {
   oidc_provider {
     issuer           = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
     audience         = "https://kubernetes.default.svc"
-    allowed_subjects = ["system:serviceaccount:hush-security:hush-agent"]
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
   }
 }
 

--- a/examples/resources/hush_deployment/resource.tf
+++ b/examples/resources/hush_deployment/resource.tf
@@ -16,7 +16,7 @@ resource "hush_deployment" "oidc" {
   oidc_provider {
     issuer           = "https://oidc.eks.us-east-1.amazonaws.com/id/D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9"
     audience         = "https://kubernetes.default.svc"
-    allowed_subjects = ["system:serviceaccount:hush-security:hush-agent"]
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
   }
 }
 


### PR DESCRIPTION
The hush_deployment oidc_provider example pinned a specific service account
name, which can be misread as a required value. Use the namespace wildcard
"system:serviceaccount:hush-security:*" so the example matches any service
account in the namespace, consistent with the CHANGELOG example.
