### PR TITLE
HUSH-6412 changelog: add 1.16.1 for oidc example doc update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.16.1] - 2026-06-24
+
+### Changed
+
+* **Docs**: the `hush_deployment` `oidc_provider` example uses a more realistic `allowed_subjects` value (`system:serviceaccount:hush-security:*`)
+
 ## [1.16.0] - 2026-06-24
 
 ### Added


### PR DESCRIPTION
Record the more realistic allowed_subjects value in the deployment
oidc_provider example as a customer-visible documentation change.
