### PR TITLE
HUSH-6439 Limit access creds to single deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.17.0] - 2026-06-30
+
+### Changed
+
+* **Access credentials and policies**: `deployment_ids` is now limited to a single deployment. A configuration that lists more than one deployment fails at plan time.
+
+```hcl
+resource "hush_postgres_access_credential" "example" {
+  name = "my-db"
+  # ...
+
+  deployment_ids = ["dep-xxxxxxxxxxxxxxxx"] # exactly one deployment
+}
+```
+
 ## [1.16.1] - 2026-06-24
 
 ### Changed

--- a/docs/data-sources/access_policy.md
+++ b/docs/data-sources/access_policy.md
@@ -52,7 +52,7 @@ output "status" {
 - `attestation_criteria` (List of Object) The attestation criteria for the access policy (see [below for nested schema](#nestedatt--attestation_criteria))
 - `aws_wif_delivery_config` (List of Object) AWS WIF delivery configuration for the access policy (see [below for nested schema](#nestedatt--aws_wif_delivery_config))
 - `azure_wif_delivery_config` (List of Object) Azure WIF delivery configuration for the access policy (see [below for nested schema](#nestedatt--azure_wif_delivery_config))
-- `deployment_ids` (List of String) The list of deployment IDs
+- `deployment_ids` (List of String) The list of deployment IDs. Currently limited to a single deployment
 - `description` (String) The description of the access policy
 - `enabled` (Boolean) Whether the access policy is enabled
 - `env_delivery_config` (List of Object) Environment variable delivery configuration for the access policy (see [below for nested schema](#nestedatt--env_delivery_config))

--- a/docs/data-sources/apigee_access_credential.md
+++ b/docs/data-sources/apigee_access_credential.md
@@ -35,7 +35,7 @@ output "has_provider_credentials" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Apigee access credential
 - `has_provider_credentials` (Boolean) Whether the credential uses provider credentials (no explicit service account key)
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/aws_access_key_access_credential.md
+++ b/docs/data-sources/aws_access_key_access_credential.md
@@ -28,7 +28,7 @@ data "hush_aws_access_key_access_credential" "example" {
 ### Read-Only
 
 - `access_key_id_value` (String) The AWS access key ID
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the AWS access key access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the AWS access key access credential

--- a/docs/data-sources/aws_wif_access_credential.md
+++ b/docs/data-sources/aws_wif_access_credential.md
@@ -40,7 +40,7 @@ output "issuer_url" {
 ### Read-Only
 
 - `audience` (String) The audience for the AWS WIF access credential
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the AWS WIF access credential
 - `issuer_url` (String) The issuer URL for the AWS WIF access credential
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/azure_app_access_credential.md
+++ b/docs/data-sources/azure_app_access_credential.md
@@ -28,7 +28,7 @@ data "hush_azure_app_access_credential" "example" {
 ### Read-Only
 
 - `client_id` (String) The Azure client ID (must be a valid UUID)
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Azure app access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Azure app access credential

--- a/docs/data-sources/azure_wif_access_credential.md
+++ b/docs/data-sources/azure_wif_access_credential.md
@@ -40,7 +40,7 @@ output "issuer_url" {
 ### Read-Only
 
 - `audience` (String) The audience for the Azure WIF access credential
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Azure WIF access credential
 - `issuer_url` (String) The issuer URL for the Azure WIF access credential
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/bedrock_access_credential.md
+++ b/docs/data-sources/bedrock_access_credential.md
@@ -44,7 +44,7 @@ output "has_provider_credentials" {
 ### Read-Only
 
 - `access_key_id` (String) The AWS access key ID. Must be set together with secret_access_key or secret_access_key_wo. Omit for provider credentials mode.
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Bedrock access credential
 - `has_provider_credentials` (Boolean) Whether the credential uses AWS provider credentials (no explicit access key)
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/datadog_access_credential.md
+++ b/docs/data-sources/datadog_access_credential.md
@@ -21,7 +21,7 @@ Use this data source to retrieve information about a Datadog access credential i
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Datadog access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Datadog access credential

--- a/docs/data-sources/elasticsearch_access_credential.md
+++ b/docs/data-sources/elasticsearch_access_credential.md
@@ -47,7 +47,7 @@ output "tls" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Elasticsearch access credential
 - `host` (String) The hostname or IP address of the Elasticsearch server
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/gcp_sa_access_credential.md
+++ b/docs/data-sources/gcp_sa_access_credential.md
@@ -27,7 +27,7 @@ data "hush_gcp_sa_access_credential" "example" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the GCP SA access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the GCP SA access credential

--- a/docs/data-sources/gcp_wif_access_credential.md
+++ b/docs/data-sources/gcp_wif_access_credential.md
@@ -40,7 +40,7 @@ output "project_number" {
 ### Read-Only
 
 - `audience` (String) The audience for the GCP WIF access credential
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the GCP WIF access credential
 - `issuer_url` (String) The issuer URL for the GCP WIF access credential
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/gemini_access_credential.md
+++ b/docs/data-sources/gemini_access_credential.md
@@ -35,7 +35,7 @@ output "project_id" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Gemini access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Gemini access credential

--- a/docs/data-sources/gitlab_access_credential.md
+++ b/docs/data-sources/gitlab_access_credential.md
@@ -40,7 +40,7 @@ output "resource_type" {
 ### Read-Only
 
 - `base_url` (String) The GitLab instance URL (default: https://gitlab.com)
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the GitLab access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the GitLab access credential

--- a/docs/data-sources/grok_access_credential.md
+++ b/docs/data-sources/grok_access_credential.md
@@ -35,7 +35,7 @@ output "team_id" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Grok access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Grok access credential

--- a/docs/data-sources/kafka_access_credential.md
+++ b/docs/data-sources/kafka_access_credential.md
@@ -44,7 +44,7 @@ output "sasl_mechanism" {
 ### Read-Only
 
 - `bootstrap_servers` (String) Comma-separated list of Kafka bootstrap brokers (host:port,host:port). Required when `engine` is `native`.
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Kafka access credential
 - `engine` (String) The Kafka engine: `native` for a self-managed/standard Kafka cluster, or `aiven` for an Aiven-managed service. Immutable; changing it forces replacement.
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/kv_access_credential.md
+++ b/docs/data-sources/kv_access_credential.md
@@ -49,7 +49,7 @@ output "credential_type" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the KV access credential
 - `keys` (List of String) List of keys available in this credential (computed)
 - `name` (String) The name of the KV access credential

--- a/docs/data-sources/mariadb_access_credential.md
+++ b/docs/data-sources/mariadb_access_credential.md
@@ -52,7 +52,7 @@ output "ssl_mode" {
 ### Read-Only
 
 - `db_name` (String) The name of the MariaDB database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the MariaDB access credential
 - `host` (String) The hostname or IP address of the MariaDB server
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/mongodb_access_credential.md
+++ b/docs/data-sources/mongodb_access_credential.md
@@ -57,7 +57,7 @@ output "tls" {
 
 - `auth_source` (String) The authentication source database (default: admin)
 - `db_name` (String) The name of the MongoDB database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the MongoDB access credential
 - `host` (String) The hostname or IP address of the MongoDB server
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/mongodb_atlas_access_credential.md
+++ b/docs/data-sources/mongodb_atlas_access_credential.md
@@ -45,7 +45,7 @@ output "db_name" {
 
 - `client_id` (String) The MongoDB Atlas service account client ID (used together with `client_secret`)
 - `db_name` (String) The name of the MongoDB Atlas database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the MongoDB Atlas access credential
 - `group_id` (String) The MongoDB Atlas project (group) ID
 - `host` (String) The hostname of the MongoDB Atlas cluster

--- a/docs/data-sources/mysql_access_credential.md
+++ b/docs/data-sources/mysql_access_credential.md
@@ -52,7 +52,7 @@ output "ssl_mode" {
 ### Read-Only
 
 - `db_name` (String) The name of the MySQL database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the MySQL access credential
 - `host` (String) The hostname or IP address of the MySQL server
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/openai_access_credential.md
+++ b/docs/data-sources/openai_access_credential.md
@@ -35,7 +35,7 @@ output "project_id" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the OpenAI access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the OpenAI access credential

--- a/docs/data-sources/plaintext_access_credential.md
+++ b/docs/data-sources/plaintext_access_credential.md
@@ -45,7 +45,7 @@ output "credential_type" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the plaintext access credential
 - `name` (String) The name of the plaintext access credential
 - `type` (String) The type of access credential (always PLAINTEXT for this resource)

--- a/docs/data-sources/postgres_access_credential.md
+++ b/docs/data-sources/postgres_access_credential.md
@@ -52,7 +52,7 @@ output "ssl_mode" {
 ### Read-Only
 
 - `db_name` (String) The name of the PostgreSQL database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the PostgreSQL access credential
 - `host` (String) The hostname or IP address of the PostgreSQL server
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/rabbitmq_access_credential.md
+++ b/docs/data-sources/rabbitmq_access_credential.md
@@ -55,7 +55,7 @@ output "tls" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the RabbitMQ access credential
 - `host` (String) The RabbitMQ host
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/redis_access_credential.md
+++ b/docs/data-sources/redis_access_credential.md
@@ -54,7 +54,7 @@ output "tls" {
 - `access_key_id` (String) The AWS access key ID used to call the ElastiCache API. Only valid when `engine` is `elasticache`. Must be set together with `secret_access_key`. Omit both to use AWS workload identity federation (IRSA / instance profile / WIF).
 - `cache_engine` (String) The AWS ElastiCache cache engine. Required and only valid when `engine` is `elasticache`. One of `redis`, `valkey`.
 - `database` (Number) The Redis database number (0-15, default: 0)
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Redis access credential
 - `engine` (String) The routing engine for this credential. `redis` connects directly to a Redis server using a password. `elasticache` provisions users via the AWS ElastiCache API.
 - `host` (String) The hostname or IP address of the Redis server

--- a/docs/data-sources/salesforce_access_credential.md
+++ b/docs/data-sources/salesforce_access_credential.md
@@ -40,7 +40,7 @@ output "client_id" {
 ### Read-Only
 
 - `client_id` (String) The Salesforce OAuth2 client ID
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Salesforce access credential
 - `instance_url` (String) The Salesforce instance URL
 - `kind` (String) The kind of access credential

--- a/docs/data-sources/sendgrid_access_credential.md
+++ b/docs/data-sources/sendgrid_access_credential.md
@@ -31,7 +31,7 @@ output "name" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the SendGrid access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the SendGrid access credential

--- a/docs/data-sources/snowflake_access_credential.md
+++ b/docs/data-sources/snowflake_access_credential.md
@@ -54,7 +54,7 @@ output "auth_method" {
 - `account` (String) The Snowflake account identifier (e.g., MYORG-MYACCOUNT)
 - `auth_method` (String) The authentication method for the Snowflake connection (password or key-pair)
 - `database` (String) The Snowflake database name
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Snowflake access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Snowflake access credential

--- a/docs/data-sources/temporal_cloud_access_credential.md
+++ b/docs/data-sources/temporal_cloud_access_credential.md
@@ -31,7 +31,7 @@ output "name" {
 
 ### Read-Only
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Temporal Cloud access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Temporal Cloud access credential

--- a/docs/data-sources/twilio_access_credential.md
+++ b/docs/data-sources/twilio_access_credential.md
@@ -41,7 +41,7 @@ output "api_key_sid" {
 
 - `account_sid` (String) The Twilio Account SID
 - `api_key_sid` (String) The Twilio API Key SID
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `description` (String) The description of the Twilio access credential
 - `kind` (String) The kind of access credential
 - `name` (String) The name of the Twilio access credential

--- a/docs/resources/access_policy.md
+++ b/docs/resources/access_policy.md
@@ -343,7 +343,7 @@ resource "hush_access_policy" "sdk_example" {
 
 - `access_credential_id` (String) The ID of the access credential
 - `attestation_criteria` (Block List, Min: 1) The attestation criteria for the access policy (see [below for nested schema](#nestedblock--attestation_criteria))
-- `deployment_ids` (List of String) The list of deployment IDs
+- `deployment_ids` (List of String) The list of deployment IDs. Currently limited to a single deployment
 - `name` (String) The name of the access policy
 
 ### Optional

--- a/docs/resources/apigee_access_credential.md
+++ b/docs/resources/apigee_access_credential.md
@@ -29,7 +29,7 @@ resource "hush_apigee_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Apigee access credential
 
 ### Optional

--- a/docs/resources/aws_access_key_access_credential.md
+++ b/docs/resources/aws_access_key_access_credential.md
@@ -28,7 +28,7 @@ resource "hush_aws_access_key_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the AWS access key access credential
 
 ### Optional

--- a/docs/resources/aws_wif_access_credential.md
+++ b/docs/resources/aws_wif_access_credential.md
@@ -26,7 +26,7 @@ resource "hush_aws_wif_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `name` (String) The name of the AWS WIF access credential
 
 ### Optional

--- a/docs/resources/azure_app_access_credential.md
+++ b/docs/resources/azure_app_access_credential.md
@@ -29,7 +29,7 @@ resource "hush_azure_app_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Azure app access credential
 - `tenant_id` (String) The Azure tenant ID (must be a valid UUID)
 

--- a/docs/resources/azure_wif_access_credential.md
+++ b/docs/resources/azure_wif_access_credential.md
@@ -26,7 +26,7 @@ resource "hush_azure_wif_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `name` (String) The name of the Azure WIF access credential
 
 ### Optional

--- a/docs/resources/bedrock_access_credential.md
+++ b/docs/resources/bedrock_access_credential.md
@@ -31,7 +31,7 @@ resource "hush_bedrock_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Bedrock access credential
 - `region` (String) The AWS region for Bedrock (e.g., us-east-1)
 

--- a/docs/resources/datadog_access_credential.md
+++ b/docs/resources/datadog_access_credential.md
@@ -17,7 +17,7 @@ Manage Datadog dynamic access credentials in the Hush Security platform.
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Datadog access credential
 
 ### Optional

--- a/docs/resources/elasticsearch_access_credential.md
+++ b/docs/resources/elasticsearch_access_credential.md
@@ -31,7 +31,7 @@ resource "hush_elasticsearch_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The hostname or IP address of the Elasticsearch server
 - `name` (String) The name of the Elasticsearch access credential
 - `username` (String) The username for the Elasticsearch connection

--- a/docs/resources/gcp_sa_access_credential.md
+++ b/docs/resources/gcp_sa_access_credential.md
@@ -27,7 +27,7 @@ resource "hush_gcp_sa_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the GCP SA access credential
 
 ### Optional

--- a/docs/resources/gcp_wif_access_credential.md
+++ b/docs/resources/gcp_wif_access_credential.md
@@ -29,7 +29,7 @@ resource "hush_gcp_wif_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment
 - `name` (String) The name of the GCP WIF access credential
 - `pool_id` (String) The workload identity pool ID
 - `project_number` (String) The GCP project number

--- a/docs/resources/gemini_access_credential.md
+++ b/docs/resources/gemini_access_credential.md
@@ -28,7 +28,7 @@ resource "hush_gemini_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Gemini access credential
 - `project_id` (String) The GCP project ID
 

--- a/docs/resources/gitlab_access_credential.md
+++ b/docs/resources/gitlab_access_credential.md
@@ -31,7 +31,7 @@ resource "hush_gitlab_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the GitLab access credential
 - `resource_id` (String) The GitLab group or project ID
 - `resource_type` (String) The type of GitLab resource to manage (group or project)

--- a/docs/resources/grok_access_credential.md
+++ b/docs/resources/grok_access_credential.md
@@ -28,7 +28,7 @@ resource "hush_grok_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Grok access credential
 - `team_id` (String) The Grok team ID
 

--- a/docs/resources/kafka_access_credential.md
+++ b/docs/resources/kafka_access_credential.md
@@ -43,7 +43,7 @@ resource "hush_kafka_access_credential" "aiven" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `engine` (String) The Kafka engine: `native` for a self-managed/standard Kafka cluster, or `aiven` for an Aiven-managed service. Immutable; changing it forces replacement.
 - `name` (String) The name of the Kafka access credential
 

--- a/docs/resources/kv_access_credential.md
+++ b/docs/resources/kv_access_credential.md
@@ -59,7 +59,7 @@ output "available_keys" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `items` (Block List, Min: 1) List of key-value pairs for the credential (see [below for nested schema](#nestedblock--items))
 - `name` (String) The name of the KV access credential
 

--- a/docs/resources/mariadb_access_credential.md
+++ b/docs/resources/mariadb_access_credential.md
@@ -33,7 +33,7 @@ resource "hush_mariadb_access_credential" "example" {
 ### Required
 
 - `db_name` (String) The name of the MariaDB database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The hostname or IP address of the MariaDB server
 - `name` (String) The name of the MariaDB access credential
 - `username` (String) The username for the MariaDB connection

--- a/docs/resources/mongodb_access_credential.md
+++ b/docs/resources/mongodb_access_credential.md
@@ -34,7 +34,7 @@ resource "hush_mongodb_access_credential" "example" {
 ### Required
 
 - `db_name` (String) The name of the MongoDB database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The hostname or IP address of the MongoDB server
 - `name` (String) The name of the MongoDB access credential
 - `username` (String) The username for the MongoDB connection

--- a/docs/resources/mongodb_atlas_access_credential.md
+++ b/docs/resources/mongodb_atlas_access_credential.md
@@ -41,7 +41,7 @@ resource "hush_mongodb_atlas_access_credential" "example" {
 ### Required
 
 - `db_name` (String) The name of the MongoDB Atlas database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `group_id` (String) The MongoDB Atlas project (group) ID
 - `host` (String) The hostname of the MongoDB Atlas cluster
 - `name` (String) The name of the MongoDB Atlas access credential

--- a/docs/resources/mysql_access_credential.md
+++ b/docs/resources/mysql_access_credential.md
@@ -33,7 +33,7 @@ resource "hush_mysql_access_credential" "example" {
 ### Required
 
 - `db_name` (String) The name of the MySQL database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The hostname or IP address of the MySQL server
 - `name` (String) The name of the MySQL access credential
 - `username` (String) The username for the MySQL connection

--- a/docs/resources/openai_access_credential.md
+++ b/docs/resources/openai_access_credential.md
@@ -28,7 +28,7 @@ resource "hush_openai_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the OpenAI access credential
 
 ### Optional

--- a/docs/resources/plaintext_access_credential.md
+++ b/docs/resources/plaintext_access_credential.md
@@ -46,7 +46,7 @@ output "credential_type" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the plaintext access credential
 
 ### Optional

--- a/docs/resources/postgres_access_credential.md
+++ b/docs/resources/postgres_access_credential.md
@@ -33,7 +33,7 @@ resource "hush_postgres_access_credential" "example" {
 ### Required
 
 - `db_name` (String) The name of the PostgreSQL database
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The hostname or IP address of the PostgreSQL server
 - `name` (String) The name of the PostgreSQL access credential
 - `username` (String) The username for the PostgreSQL connection

--- a/docs/resources/rabbitmq_access_credential.md
+++ b/docs/resources/rabbitmq_access_credential.md
@@ -33,7 +33,7 @@ resource "hush_rabbitmq_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `host` (String) The RabbitMQ host
 - `name` (String) The name of the RabbitMQ access credential
 

--- a/docs/resources/redis_access_credential.md
+++ b/docs/resources/redis_access_credential.md
@@ -52,7 +52,7 @@ resource "hush_redis_access_credential" "elasticache_example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `engine` (String) The routing engine for this credential. `redis` connects directly to a Redis server using a password. `elasticache` provisions users via the AWS ElastiCache API.
 - `host` (String) The hostname or IP address of the Redis server
 - `name` (String) The name of the Redis access credential

--- a/docs/resources/salesforce_access_credential.md
+++ b/docs/resources/salesforce_access_credential.md
@@ -32,7 +32,7 @@ resource "hush_salesforce_access_credential" "example" {
 ### Required
 
 - `client_id` (String) The Salesforce OAuth2 client ID
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `instance_url` (String) The Salesforce instance URL
 - `name` (String) The name of the Salesforce access credential
 

--- a/docs/resources/sendgrid_access_credential.md
+++ b/docs/resources/sendgrid_access_credential.md
@@ -29,7 +29,7 @@ resource "hush_sendgrid_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the SendGrid access credential
 
 ### Optional

--- a/docs/resources/snowflake_access_credential.md
+++ b/docs/resources/snowflake_access_credential.md
@@ -51,7 +51,7 @@ resource "hush_snowflake_access_credential" "keypair" {
 - `account` (String) The Snowflake account identifier (e.g., MYORG-MYACCOUNT)
 - `auth_method` (String) The authentication method for the Snowflake connection (password or key-pair)
 - `database` (String) The Snowflake database name
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Snowflake access credential
 - `username` (String) The username for the Snowflake connection
 - `warehouse` (String) The Snowflake warehouse name

--- a/docs/resources/temporal_cloud_access_credential.md
+++ b/docs/resources/temporal_cloud_access_credential.md
@@ -28,7 +28,7 @@ resource "hush_temporal_cloud_access_credential" "example" {
 
 ### Required
 
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Temporal Cloud access credential
 
 ### Optional

--- a/docs/resources/twilio_access_credential.md
+++ b/docs/resources/twilio_access_credential.md
@@ -33,7 +33,7 @@ resource "hush_twilio_access_credential" "example" {
 
 - `account_sid` (String) The Twilio Account SID
 - `api_key_sid` (String) The Twilio API Key SID
-- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Changing this after creation is not supported; the credential must be deleted and recreated.
+- `deployment_ids` (List of String) List of deployment IDs that can access this credential. Currently limited to a single deployment. Changing this after creation is not supported; the credential must be deleted and recreated.
 - `name` (String) The name of the Twilio access credential
 
 ### Optional

--- a/internal/provider/acc_tests/access_credential_deployment_limit_test.go
+++ b/internal/provider/acc_tests/access_credential_deployment_limit_test.go
@@ -1,0 +1,160 @@
+package acc_tests
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// deployment_ids is capped at a single deployment (schema MaxItems: 1) on every
+// access-credential kind. Each config below is an otherwise-valid single-deployment
+// config (reused from each kind's acceptance test where one exists); twoDeployments
+// adds a second deployment so the only validation error is the cap. A regression
+// that drops MaxItems from any kind makes that kind's subtest fail.
+func TestAccResourceAccessCredentials_RejectMultipleDeployments(t *testing.T) {
+	twoDeployments := func(cfg string) string {
+		return strings.Replace(
+			cfg,
+			`["`+mockDeploymentID+`"]`,
+			`["`+mockDeploymentID+`", "`+mockDeploymentID2+`"]`,
+			1,
+		)
+	}
+
+	configs := map[string]string{
+		"hush_apigee_access_credential":         apigeeAccessCredentialStep1(),
+		"hush_aws_wif_access_credential":        awsWifAccessCredentialStep1(),
+		"hush_azure_wif_access_credential":      azureWifAccessCredentialStep1(),
+		"hush_bedrock_access_credential":        bedrockAccessCredentialStep1(),
+		"hush_datadog_access_credential":        datadogAccessCredentialStep1(),
+		"hush_gcp_sa_access_credential":         gcpSAAccessCredentialStep1(),
+		"hush_gcp_wif_access_credential":        gcpWifAccessCredentialStep1(),
+		"hush_gemini_access_credential":         geminiAccessCredentialStep1(),
+		"hush_kafka_access_credential":          kafkaAccessCredentialNativeStep1(),
+		"hush_mariadb_access_credential":        mariadbAccessCredentialStep1(),
+		"hush_mongodb_access_credential":        mongodbAccessCredentialStep1(),
+		"hush_mongodb_atlas_access_credential":  mongodbAtlasAccessCredentialStep1(),
+		"hush_mysql_access_credential":          mysqlAccessCredentialStep1(),
+		"hush_postgres_access_credential":       postgresAccessCredentialStep1(),
+		"hush_redis_access_credential":          redisAccessCredentialStep1(),
+		"hush_salesforce_access_credential":     salesforceAccessCredentialStep1(),
+		"hush_sendgrid_access_credential":       sendgridAccessCredentialStep1(),
+		"hush_snowflake_access_credential":      snowflakeAccessCredentialStep1(),
+		"hush_temporal_cloud_access_credential": temporalCloudAccessCredentialStep1(),
+		"hush_aws_access_key_access_credential": `
+resource "hush_aws_access_key_access_credential" "test" {
+  name                = "test-aws-cred"
+  description         = "test aws credential"
+  deployment_ids      = ["` + mockDeploymentID + `"]
+  access_key_id_value = "` + mockAWSAccessKeyID + `"
+  secret_access_key   = "` + mockAWSSecretAccessKey + `"
+}
+`,
+		"hush_azure_app_access_credential": `
+resource "hush_azure_app_access_credential" "test" {
+  name           = "test-azure-cred"
+  description    = "test azure credential"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  tenant_id      = "` + mockAzureTenantID + `"
+  client_id      = "` + mockAzureClientID + `"
+  client_secret  = "` + mockAzureClientSecret + `"
+}
+`,
+		"hush_elasticsearch_access_credential": `
+resource "hush_elasticsearch_access_credential" "test" {
+  name           = "test-es-cred"
+  description    = "test elasticsearch credential"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  host           = "` + mockElasticsearchHost + `"
+  port           = 9200
+  username       = "` + mockElasticsearchUsername + `"
+  password       = "` + mockElasticsearchPassword + `"
+  tls            = false
+}
+`,
+		"hush_gitlab_access_credential": `
+resource "hush_gitlab_access_credential" "test" {
+  name           = "test-gitlab-cred"
+  description    = "test gitlab credential"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  token          = "` + mockGitlabToken + `"
+  resource_type  = "group"
+  resource_id    = "` + mockGitlabResourceID + `"
+}
+`,
+		"hush_grok_access_credential": `
+resource "hush_grok_access_credential" "test" {
+  name           = "test-grok-cred"
+  description    = "test grok credential"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  api_key        = "` + mockGrokAPIKey + `"
+  team_id        = "` + mockGrokTeamID + `"
+}
+`,
+		"hush_openai_access_credential": `
+resource "hush_openai_access_credential" "test" {
+  name           = "test-openai-cred"
+  description    = "test openai credential"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  api_key        = "` + mockOpenAIAPIKey + `"
+  project_id     = "` + mockOpenAIProjectID + `"
+}
+`,
+		"hush_rabbitmq_access_credential": `
+resource "hush_rabbitmq_access_credential" "test" {
+  name            = "test-rabbitmq-cred"
+  description     = "test rabbitmq credential"
+  deployment_ids  = ["` + mockDeploymentID + `"]
+  host            = "` + mockRabbitmqHost + `"
+  port            = 5672
+  management_port = 15672
+  username        = "` + mockRabbitmqUsername + `"
+  password        = "` + mockRabbitmqPassword + `"
+  vhost           = "/"
+  tls             = false
+}
+`,
+		"hush_kv_access_credential": `
+resource "hush_kv_access_credential" "test" {
+  name           = "test-kv-cred"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  items {
+    key   = "k"
+    value = "v"
+  }
+}
+`,
+		"hush_plaintext_access_credential": `
+resource "hush_plaintext_access_credential" "test" {
+  name           = "test-plaintext-cred"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  secret         = "s3cret"
+}
+`,
+		"hush_twilio_access_credential": `
+resource "hush_twilio_access_credential" "test" {
+  name           = "test-twilio-cred"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  account_sid    = "AC00000000000000000000000000000000"
+  api_key_sid    = "SK00000000000000000000000000000000"
+  api_key_secret = "test-twilio-api-key-secret"
+}
+`,
+	}
+
+	for resourceType, cfg := range configs {
+		t.Run(resourceType, func(t *testing.T) {
+			resource.ParallelTest(t, resource.TestCase{
+				ProviderFactories: providerFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:      twoDeployments(cfg),
+						ExpectError: regexp.MustCompile(`supports 1 item maximum`),
+					},
+				},
+			})
+		})
+	}
+}

--- a/internal/provider/acc_tests/access_policy_test.go
+++ b/internal/provider/acc_tests/access_policy_test.go
@@ -553,7 +553,7 @@ func TestAccResourceAccessPolicy_withAwsWifDelivery(t *testing.T) {
 						"hush_access_policy.test", "description", "updated AWS WIF delivery policy",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_access_policy.test", "deployment_ids.#", "2",
+						"hush_access_policy.test", "deployment_ids.#", "1",
 					),
 					resource.TestCheckResourceAttr(
 						"hush_access_policy.test", "aws_wif_delivery_config.0.role_arn", "arn:aws:iam::123456789012:role/updated-role",
@@ -653,7 +653,7 @@ func accessPolicyAwsWifDeliveryStep2() string {
 resource "hush_aws_wif_access_credential" "test" {
   name           = "test-aws-wif-cred"
   description    = "AWS WIF credential for access policy test"
-  deployment_ids = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+  deployment_ids = ["` + mockDeploymentID + `"]
 }
 
 resource "hush_access_policy" "test" {
@@ -661,7 +661,7 @@ resource "hush_access_policy" "test" {
   description          = "updated AWS WIF delivery policy"
   enabled              = true
   access_credential_id = hush_aws_wif_access_credential.test.id
-  deployment_ids       = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+  deployment_ids       = ["` + mockDeploymentID + `"]
 
   attestation_criteria {
     type  = "k8s:ns"
@@ -1239,4 +1239,37 @@ resource "hush_access_policy" "test" {
   }
 }
 `
+}
+
+// Negative test: deployment_ids is capped at one (schema MaxItems: 1).
+func TestAccResourceAccessPolicy_RejectsMultipleDeployments(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+resource "hush_access_policy" "test" {
+  name                 = "test-policy"
+  description          = "test policy description"
+  enabled              = true
+  access_credential_id = "` + mockAccessCredentialID + `"
+  access_privilege_ids = ["` + mockAccessPrivilegeID + `"]
+  deployment_ids       = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+
+  attestation_criteria {
+    type  = "k8s:ns"
+    value = "default"
+  }
+
+  env_delivery_config {
+    key  = "port"
+    name = "PORT"
+    type = "key"
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`supports 1 item maximum`),
+			},
+		},
+	})
 }

--- a/internal/provider/acc_tests/aws_wif_access_credential_test.go
+++ b/internal/provider/acc_tests/aws_wif_access_credential_test.go
@@ -63,13 +63,10 @@ func TestAccResourceAwsWifAccessCredential(t *testing.T) {
 						"hush_aws_wif_access_credential.test", "description", "updated aws wif credential",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_aws_wif_access_credential.test", "deployment_ids.#", "2",
+						"hush_aws_wif_access_credential.test", "deployment_ids.#", "1",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_aws_wif_access_credential.test", "deployment_ids.0", mockDeploymentID,
-					),
-					resource.TestCheckResourceAttr(
-						"hush_aws_wif_access_credential.test", "deployment_ids.1", mockDeploymentID2,
+						"hush_aws_wif_access_credential.test", "deployment_ids.0", mockDeploymentID2,
 					),
 				),
 			},
@@ -115,7 +112,7 @@ func awsWifAccessCredentialStep2() string {
 resource "hush_aws_wif_access_credential" "test" {
   name           = "test-aws-wif-cred-updated"
   description    = "updated aws wif credential"
-  deployment_ids = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+  deployment_ids = ["` + mockDeploymentID2 + `"]
 }
 `
 }

--- a/internal/provider/acc_tests/azure_wif_access_credential_test.go
+++ b/internal/provider/acc_tests/azure_wif_access_credential_test.go
@@ -63,13 +63,10 @@ func TestAccResourceAzureWifAccessCredential(t *testing.T) {
 						"hush_azure_wif_access_credential.test", "description", "updated azure wif credential",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_azure_wif_access_credential.test", "deployment_ids.#", "2",
+						"hush_azure_wif_access_credential.test", "deployment_ids.#", "1",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_azure_wif_access_credential.test", "deployment_ids.0", mockDeploymentID,
-					),
-					resource.TestCheckResourceAttr(
-						"hush_azure_wif_access_credential.test", "deployment_ids.1", mockDeploymentID2,
+						"hush_azure_wif_access_credential.test", "deployment_ids.0", mockDeploymentID2,
 					),
 				),
 			},
@@ -115,7 +112,7 @@ func azureWifAccessCredentialStep2() string {
 resource "hush_azure_wif_access_credential" "test" {
   name           = "test-azure-wif-cred-updated"
   description    = "updated azure wif credential"
-  deployment_ids = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+  deployment_ids = ["` + mockDeploymentID2 + `"]
 }
 `
 }

--- a/internal/provider/acc_tests/gcp_wif_access_credential_test.go
+++ b/internal/provider/acc_tests/gcp_wif_access_credential_test.go
@@ -68,13 +68,10 @@ func TestAccResourceGcpWifAccessCredential(t *testing.T) {
 						"hush_gcp_wif_access_credential.test", "description", "updated gcp wif credential",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_gcp_wif_access_credential.test", "deployment_ids.#", "2",
+						"hush_gcp_wif_access_credential.test", "deployment_ids.#", "1",
 					),
 					resource.TestCheckResourceAttr(
-						"hush_gcp_wif_access_credential.test", "deployment_ids.0", mockDeploymentID,
-					),
-					resource.TestCheckResourceAttr(
-						"hush_gcp_wif_access_credential.test", "deployment_ids.1", mockDeploymentID2,
+						"hush_gcp_wif_access_credential.test", "deployment_ids.0", mockDeploymentID2,
 					),
 					resource.TestCheckResourceAttr(
 						"hush_gcp_wif_access_credential.test", "project_number", "987654321098",
@@ -138,7 +135,7 @@ func gcpWifAccessCredentialStep2() string {
 resource "hush_gcp_wif_access_credential" "test" {
   name                 = "test-gcp-wif-cred-updated"
   description          = "updated gcp wif credential"
-  deployment_ids       = ["` + mockDeploymentID + `", "` + mockDeploymentID2 + `"]
+  deployment_ids       = ["` + mockDeploymentID2 + `"]
   project_number       = "987654321098"
   pool_id              = "my-wif-pool-updated"
   workload_provider_id = "my-wif-provider-updated"

--- a/internal/provider/access_policy/common.go
+++ b/internal/provider/access_policy/common.go
@@ -78,6 +78,7 @@ func AccessPolicyResourceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			Required:    true,
 			MinItems:    1,
+			MaxItems:    1,
 			Description: deploymentIDsDesc,
 			Elem: &schema.Schema{
 				Type:         schema.TypeString,

--- a/internal/provider/access_policy/common.go
+++ b/internal/provider/access_policy/common.go
@@ -18,7 +18,7 @@ const (
 	enabledDesc                = "Whether the access policy is enabled"
 	accessCredentialIDDesc     = "The ID of the access credential"
 	accessPrivilegeIDsDesc     = "The list of access privilege IDs"
-	deploymentIDsDesc          = "The list of deployment IDs"
+	deploymentIDsDesc          = "The list of deployment IDs. Currently limited to a single deployment"
 	attestationCriteriaDesc    = "The attestation criteria for the access policy"
 	envDeliveryConfigDesc      = "Environment variable delivery configuration for the access policy"
 	volumeDeliveryConfigDesc   = "Volume mount delivery configuration for the access policy"

--- a/internal/provider/apigee_access_credential/common.go
+++ b/internal/provider/apigee_access_credential/common.go
@@ -45,6 +45,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/apigee_access_credential/common.go
+++ b/internal/provider/apigee_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                    = "The unique identifier of the Apigee access credential"
 	nameDesc                  = "The name of the Apigee access credential"
 	descriptionDesc           = "The description of the Apigee access credential"
-	deploymentIDsDesc         = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc         = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	serviceAccountKeyDesc     = "The GCP service account key JSON content"
 	serviceAccountKeyWODesc   = "The GCP service account key JSON content (write-only). This is a write-only attribute that is more secure than `service_account_key` because Terraform will not store this value in the state file."
 	serviceAccountKeyWOVerDsc = "Used to trigger updates for `service_account_key_wo`. This value should be changed when the service account key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/aws_access_key_access_credential/common.go
+++ b/internal/provider/aws_access_key_access_credential/common.go
@@ -46,6 +46,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/aws_access_key_access_credential/common.go
+++ b/internal/provider/aws_access_key_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                   = "The unique identifier of the AWS access key access credential"
 	nameDesc                 = "The name of the AWS access key access credential"
 	descriptionDesc          = "The description of the AWS access key access credential"
-	deploymentIDsDesc        = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc        = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	accessKeyIDValueDesc     = "The AWS access key ID"
 	secretAccessKeyDesc      = "The AWS secret access key"
 	secretAccessKeyWODesc    = "The AWS secret access key (write-only). This is a write-only attribute that is more secure than `secret_access_key` because Terraform will not store this value in the state file. Either `secret_access_key` or `secret_access_key_wo` must be specified."

--- a/internal/provider/aws_wif_access_credential/common.go
+++ b/internal/provider/aws_wif_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the AWS WIF access credential"
 	nameDesc          = "The name of the AWS WIF access credential"
 	descriptionDesc   = "The description of the AWS WIF access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	audienceDesc      = "The audience for the AWS WIF access credential"
 	issuerURLDesc     = "The issuer URL for the AWS WIF access credential"
 	typeDesc          = "The type of access credential"

--- a/internal/provider/aws_wif_access_credential/common.go
+++ b/internal/provider/aws_wif_access_credential/common.go
@@ -43,6 +43,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/azure_app_access_credential/common.go
+++ b/internal/provider/azure_app_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc              = "The unique identifier of the Azure app access credential"
 	nameDesc            = "The name of the Azure app access credential"
 	descriptionDesc     = "The description of the Azure app access credential"
-	deploymentIDsDesc   = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc   = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	tenantIDDesc        = "The Azure tenant ID (must be a valid UUID)"
 	clientIDDesc        = "The Azure client ID (must be a valid UUID)"
 	clientSecretDesc    = "The Azure client secret"

--- a/internal/provider/azure_app_access_credential/common.go
+++ b/internal/provider/azure_app_access_credential/common.go
@@ -48,6 +48,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/azure_wif_access_credential/common.go
+++ b/internal/provider/azure_wif_access_credential/common.go
@@ -43,6 +43,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/azure_wif_access_credential/common.go
+++ b/internal/provider/azure_wif_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Azure WIF access credential"
 	nameDesc          = "The name of the Azure WIF access credential"
 	descriptionDesc   = "The description of the Azure WIF access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	audienceDesc      = "The audience for the Azure WIF access credential"
 	issuerURLDesc     = "The issuer URL for the Azure WIF access credential"
 	typeDesc          = "The type of access credential"

--- a/internal/provider/bedrock_access_credential/common.go
+++ b/internal/provider/bedrock_access_credential/common.go
@@ -49,6 +49,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/bedrock_access_credential/common.go
+++ b/internal/provider/bedrock_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                   = "The unique identifier of the Bedrock access credential"
 	nameDesc                 = "The name of the Bedrock access credential"
 	descriptionDesc          = "The description of the Bedrock access credential"
-	deploymentIDsDesc        = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc        = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	regionDesc               = "The AWS region for Bedrock (e.g., us-east-1)"
 	accessKeyIDDesc          = "The AWS access key ID. Must be set together with secret_access_key or secret_access_key_wo. Omit for provider credentials mode."
 	secretAccessKeyDesc      = "The AWS secret access key"

--- a/internal/provider/datadog_access_credential/common.go
+++ b/internal/provider/datadog_access_credential/common.go
@@ -48,6 +48,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/datadog_access_credential/common.go
+++ b/internal/provider/datadog_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Datadog access credential"
 	nameDesc          = "The name of the Datadog access credential"
 	descriptionDesc   = "The description of the Datadog access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	apiKeyDesc        = "The Datadog API key"
 	apiKeyWODesc      = "The Datadog API key (write-only). This is a write-only attribute that is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
 	apiKeyWOVerDesc   = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/elasticsearch_access_credential/common.go
+++ b/internal/provider/elasticsearch_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Elasticsearch access credential"
 	nameDesc          = "The name of the Elasticsearch access credential"
 	descriptionDesc   = "The description of the Elasticsearch access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	hostDesc          = "The hostname or IP address of the Elasticsearch server"
 	portDesc          = "The port number of the Elasticsearch server (default: 9200)"
 	usernameDesc      = "The username for the Elasticsearch connection"

--- a/internal/provider/elasticsearch_access_credential/common.go
+++ b/internal/provider/elasticsearch_access_credential/common.go
@@ -49,6 +49,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/gcp_sa_access_credential/common.go
+++ b/internal/provider/gcp_sa_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                     = "The unique identifier of the GCP SA access credential"
 	nameDesc                   = "The name of the GCP SA access credential"
 	descriptionDesc            = "The description of the GCP SA access credential"
-	deploymentIDsDesc          = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc          = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	serviceAccountKeyDesc      = "The GCP SA key JSON"
 	serviceAccountKeyWODesc    = "The GCP SA key JSON (write-only). This is a write-only attribute that is more secure than `service_account_key` because Terraform will not store this value in the state file. Either `service_account_key` or `service_account_key_wo` must be specified."
 	serviceAccountKeyWOVerDesc = "Used to trigger updates for `service_account_key_wo`. This value should be changed when the service account key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/gcp_sa_access_credential/common.go
+++ b/internal/provider/gcp_sa_access_credential/common.go
@@ -44,6 +44,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/gcp_wif_access_credential/common.go
+++ b/internal/provider/gcp_wif_access_credential/common.go
@@ -46,6 +46,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/gcp_wif_access_credential/common.go
+++ b/internal/provider/gcp_wif_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                 = "The unique identifier of the GCP WIF access credential"
 	nameDesc               = "The name of the GCP WIF access credential"
 	descriptionDesc        = "The description of the GCP WIF access credential"
-	deploymentIDsDesc      = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc      = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	projectNumberDesc      = "The GCP project number"
 	poolIDDesc             = "The workload identity pool ID"
 	workloadProviderIDDesc = "The workload identity provider ID"

--- a/internal/provider/gemini_access_credential/common.go
+++ b/internal/provider/gemini_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                     = "The unique identifier of the Gemini access credential"
 	nameDesc                   = "The name of the Gemini access credential"
 	descriptionDesc            = "The description of the Gemini access credential"
-	deploymentIDsDesc          = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc          = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	serviceAccountKeyDesc      = "The GCP service account key JSON"
 	serviceAccountKeyWODesc    = "The GCP service account key JSON (write-only). This is a write-only attribute that is more secure than `service_account_key` because Terraform will not store this value in the state file. Either `service_account_key` or `service_account_key_wo` must be specified."
 	serviceAccountKeyWOVerDesc = "Used to trigger updates for `service_account_key_wo`. This value should be changed when the service account key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/gemini_access_credential/common.go
+++ b/internal/provider/gemini_access_credential/common.go
@@ -45,6 +45,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/gitlab_access_credential/common.go
+++ b/internal/provider/gitlab_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the GitLab access credential"
 	nameDesc          = "The name of the GitLab access credential"
 	descriptionDesc   = "The description of the GitLab access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	tokenDesc         = "The GitLab API token"
 	tokenWODesc       = "The GitLab API token (write-only). More secure than `token` because Terraform will not store this value in the state file."
 	tokenWOVerDesc    = "Used to trigger updates for `token_wo`. Change when the token changes."

--- a/internal/provider/gitlab_access_credential/common.go
+++ b/internal/provider/gitlab_access_credential/common.go
@@ -47,6 +47,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/grok_access_credential/common.go
+++ b/internal/provider/grok_access_credential/common.go
@@ -45,6 +45,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/grok_access_credential/common.go
+++ b/internal/provider/grok_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Grok access credential"
 	nameDesc          = "The name of the Grok access credential"
 	descriptionDesc   = "The description of the Grok access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	apiKeyDesc        = "The Grok API key"
 	apiKeyWODesc      = "The Grok API key (write-only). This is a write-only attribute that is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
 	apiKeyWOVerDesc   = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/kafka_access_credential/common.go
+++ b/internal/provider/kafka_access_credential/common.go
@@ -65,6 +65,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/kafka_access_credential/common.go
+++ b/internal/provider/kafka_access_credential/common.go
@@ -21,7 +21,7 @@ const (
 	idDesc               = "The unique identifier of the Kafka access credential"
 	nameDesc             = "The name of the Kafka access credential"
 	descriptionDesc      = "The description of the Kafka access credential"
-	deploymentIDsDesc    = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc    = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	engineDesc           = "The Kafka engine: `native` for a self-managed/standard Kafka cluster, or `aiven` for an Aiven-managed service. Immutable; changing it forces replacement."
 	bootstrapServersDesc = "Comma-separated list of Kafka bootstrap brokers (host:port,host:port). Required when `engine` is `native`."
 	usernameDesc         = "The SASL username for the root Kafka connection. Required when `engine` is `native`."

--- a/internal/provider/kv_access_credential/common.go
+++ b/internal/provider/kv_access_credential/common.go
@@ -44,6 +44,7 @@ func KVAccessCredentialResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/kv_access_credential/common.go
+++ b/internal/provider/kv_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the KV access credential"
 	nameDesc          = "The name of the KV access credential"
 	descriptionDesc   = "The description of the KV access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	itemsDesc         = "List of key-value pairs for the credential"
 	keyDesc           = "The key name for the environment variable"
 	valueDesc         = "The value for the key-value pair"

--- a/internal/provider/mariadb_access_credential/common.go
+++ b/internal/provider/mariadb_access_credential/common.go
@@ -50,6 +50,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/mariadb_access_credential/common.go
+++ b/internal/provider/mariadb_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the MariaDB access credential"
 	nameDesc          = "The name of the MariaDB access credential"
 	descriptionDesc   = "The description of the MariaDB access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	dbNameDesc        = "The name of the MariaDB database"
 	hostDesc          = "The hostname or IP address of the MariaDB server"
 	portDesc          = "The port number of the MariaDB server (default: 3306)"

--- a/internal/provider/mongodb_access_credential/common.go
+++ b/internal/provider/mongodb_access_credential/common.go
@@ -51,6 +51,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/mongodb_access_credential/common.go
+++ b/internal/provider/mongodb_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the MongoDB access credential"
 	nameDesc          = "The name of the MongoDB access credential"
 	descriptionDesc   = "The description of the MongoDB access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	dbNameDesc        = "The name of the MongoDB database"
 	hostDesc          = "The hostname or IP address of the MongoDB server"
 	portDesc          = "The port number of the MongoDB server (default: 27017)"

--- a/internal/provider/mongodb_atlas_access_credential/common.go
+++ b/internal/provider/mongodb_atlas_access_credential/common.go
@@ -52,6 +52,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/mongodb_atlas_access_credential/common.go
+++ b/internal/provider/mongodb_atlas_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc              = "The unique identifier of the MongoDB Atlas access credential"
 	nameDesc            = "The name of the MongoDB Atlas access credential"
 	descriptionDesc     = "The description of the MongoDB Atlas access credential"
-	deploymentIDsDesc   = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc   = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	groupIDDesc         = "The MongoDB Atlas project (group) ID"
 	dbNameDesc          = "The name of the MongoDB Atlas database"
 	hostDesc            = "The hostname of the MongoDB Atlas cluster"

--- a/internal/provider/mysql_access_credential/common.go
+++ b/internal/provider/mysql_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the MySQL access credential"
 	nameDesc          = "The name of the MySQL access credential"
 	descriptionDesc   = "The description of the MySQL access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	dbNameDesc        = "The name of the MySQL database"
 	hostDesc          = "The hostname or IP address of the MySQL server"
 	portDesc          = "The port number of the MySQL server (default: 3306)"

--- a/internal/provider/mysql_access_credential/common.go
+++ b/internal/provider/mysql_access_credential/common.go
@@ -50,6 +50,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/openai_access_credential/common.go
+++ b/internal/provider/openai_access_credential/common.go
@@ -45,6 +45,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/openai_access_credential/common.go
+++ b/internal/provider/openai_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the OpenAI access credential"
 	nameDesc          = "The name of the OpenAI access credential"
 	descriptionDesc   = "The description of the OpenAI access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	apiKeyDesc        = "The OpenAI API key"
 	apiKeyWODesc      = "The OpenAI API key (write-only). This is a write-only attribute that is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
 	apiKeyWOVerDesc   = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/plaintext_access_credential/common.go
+++ b/internal/provider/plaintext_access_credential/common.go
@@ -43,6 +43,7 @@ func PlaintextAccessCredentialResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/plaintext_access_credential/common.go
+++ b/internal/provider/plaintext_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc              = "The unique identifier of the plaintext access credential"
 	nameDesc            = "The name of the plaintext access credential"
 	descriptionDesc     = "The description of the plaintext access credential"
-	deploymentIDsDesc   = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc   = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	secretDesc          = "The secret value for the plaintext credential"
 	secretWODesc        = "The secret value for the plaintext credential (write-only). This is a write-only attribute that is more secure than `secret` because Terraform will not store this value in the state file. Either `secret` or `secret_wo` must be specified."
 	secretWOVersionDesc = "Used to trigger updates for `secret_wo`. This value should be changed when the secret content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/postgres_access_credential/common.go
+++ b/internal/provider/postgres_access_credential/common.go
@@ -50,6 +50,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/postgres_access_credential/common.go
+++ b/internal/provider/postgres_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the PostgreSQL access credential"
 	nameDesc          = "The name of the PostgreSQL access credential"
 	descriptionDesc   = "The description of the PostgreSQL access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	dbNameDesc        = "The name of the PostgreSQL database"
 	hostDesc          = "The hostname or IP address of the PostgreSQL server"
 	portDesc          = "The port number of the PostgreSQL server (default: 5432)"

--- a/internal/provider/rabbitmq_access_credential/common.go
+++ b/internal/provider/rabbitmq_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc             = "The unique identifier of the RabbitMQ access credential"
 	nameDesc           = "The name of the RabbitMQ access credential"
 	descriptionDesc    = "The description of the RabbitMQ access credential"
-	deploymentIDsDesc  = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc  = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	hostDesc           = "The RabbitMQ host"
 	portDesc           = "The RabbitMQ AMQP port (default: 5672)"
 	managementPortDesc = "The RabbitMQ management API port (default: 15672)"

--- a/internal/provider/rabbitmq_access_credential/common.go
+++ b/internal/provider/rabbitmq_access_credential/common.go
@@ -51,6 +51,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/redis_access_credential/common.go
+++ b/internal/provider/redis_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                 = "The unique identifier of the Redis access credential"
 	nameDesc               = "The name of the Redis access credential"
 	descriptionDesc        = "The description of the Redis access credential"
-	deploymentIDsDesc      = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc      = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	hostDesc               = "The hostname or IP address of the Redis server"
 	portDesc               = "The port number of the Redis server (default: 6379)"
 	usernameDesc           = "The username for the Redis connection (Redis 6+ ACL)"

--- a/internal/provider/redis_access_credential/common.go
+++ b/internal/provider/redis_access_credential/common.go
@@ -58,6 +58,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/salesforce_access_credential/common.go
+++ b/internal/provider/salesforce_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc              = "The unique identifier of the Salesforce access credential"
 	nameDesc            = "The name of the Salesforce access credential"
 	descriptionDesc     = "The description of the Salesforce access credential"
-	deploymentIDsDesc   = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc   = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	instanceURLDesc     = "The Salesforce instance URL"
 	clientIDDesc        = "The Salesforce OAuth2 client ID"
 	clientSecretDesc    = "The Salesforce OAuth2 client secret"

--- a/internal/provider/salesforce_access_credential/common.go
+++ b/internal/provider/salesforce_access_credential/common.go
@@ -46,6 +46,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/sendgrid_access_credential/common.go
+++ b/internal/provider/sendgrid_access_credential/common.go
@@ -44,6 +44,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/sendgrid_access_credential/common.go
+++ b/internal/provider/sendgrid_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the SendGrid access credential"
 	nameDesc          = "The name of the SendGrid access credential"
 	descriptionDesc   = "The description of the SendGrid access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	apiKeyDesc        = "The SendGrid API key"
 	apiKeyWODesc      = "The SendGrid API key (write-only). More secure than `api_key` because Terraform will not store this value in the state file."
 	apiKeyWOVerDesc   = "Used to trigger updates for `api_key_wo`. Change when the API key changes."

--- a/internal/provider/snowflake_access_credential/common.go
+++ b/internal/provider/snowflake_access_credential/common.go
@@ -54,6 +54,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/snowflake_access_credential/common.go
+++ b/internal/provider/snowflake_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Snowflake access credential"
 	nameDesc          = "The name of the Snowflake access credential"
 	descriptionDesc   = "The description of the Snowflake access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	accountDesc       = "The Snowflake account identifier (e.g., MYORG-MYACCOUNT)"
 	warehouseDesc     = "The Snowflake warehouse name"
 	databaseDesc      = "The Snowflake database name"

--- a/internal/provider/temporal_cloud_access_credential/common.go
+++ b/internal/provider/temporal_cloud_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc            = "The unique identifier of the Temporal Cloud access credential"
 	nameDesc          = "The name of the Temporal Cloud access credential"
 	descriptionDesc   = "The description of the Temporal Cloud access credential"
-	deploymentIDsDesc = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	apiKeyDesc        = "The Temporal Cloud API key"
 	apiKeyWODesc      = "The Temporal Cloud API key (write-only). This is a write-only attribute that is more secure than `api_key` because Terraform will not store this value in the state file. Either `api_key` or `api_key_wo` must be specified."
 	apiKeyWOVerDesc   = "Used to trigger updates for `api_key_wo`. This value should be changed when the API key content changes. Can be any value (e.g., a timestamp, version number, or hash)."

--- a/internal/provider/temporal_cloud_access_credential/common.go
+++ b/internal/provider/temporal_cloud_access_credential/common.go
@@ -44,6 +44,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),

--- a/internal/provider/twilio_access_credential/common.go
+++ b/internal/provider/twilio_access_credential/common.go
@@ -11,7 +11,7 @@ const (
 	idDesc                = "The unique identifier of the Twilio access credential"
 	nameDesc              = "The name of the Twilio access credential"
 	descriptionDesc       = "The description of the Twilio access credential"
-	deploymentIDsDesc     = "List of deployment IDs that can access this credential"
+	deploymentIDsDesc     = "List of deployment IDs that can access this credential. Currently limited to a single deployment"
 	accountSIDDesc        = "The Twilio Account SID"
 	apiKeySIDDesc         = "The Twilio API Key SID"
 	apiKeySecretDesc      = "The Twilio API Key Secret"

--- a/internal/provider/twilio_access_credential/common.go
+++ b/internal/provider/twilio_access_credential/common.go
@@ -46,6 +46,7 @@ func ResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
+		MaxItems:    1,
 		Elem: &schema.Schema{
 			Type:         schema.TypeString,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^dep-`), "deployment_id must start with 'dep-'"),


### PR DESCRIPTION
- **HUSH-6439 access-credential: limit deployment_ids to a single deployment**
- **HUSH-6439 test: adjust acceptance tests for the single-deployment limit**
