### PR TITLE
HUSH-6700 plaintext/kv access credentials: rotate secret in place

### DIFF
--- a/internal/client/access_credential.go
+++ b/internal/client/access_credential.go
@@ -58,10 +58,18 @@ type CreateKVAccessCredentialInput struct {
 	Items         []KVItem `json:"items"`
 }
 
-type UpdateAccessCredentialInput struct {
+type UpdatePlaintextAccessCredentialInput struct {
 	Name          *string `json:"name,omitempty"`
 	Description   *string `json:"description,omitempty"`
 	SecretStoreID *string `json:"secret_store_id,omitempty"`
+	Secret        *string `json:"secret,omitempty"`
+}
+
+type UpdateKVAccessCredentialInput struct {
+	Name          *string  `json:"name,omitempty"`
+	Description   *string  `json:"description,omitempty"`
+	SecretStoreID *string  `json:"secret_store_id,omitempty"`
+	Items         []KVItem `json:"items,omitempty"`
 }
 
 type AccessCredentialListResponse struct {
@@ -119,7 +127,7 @@ func GetKVAccessCredential(ctx context.Context, c *Client, id string) (*AccessCr
 	return &cred, nil
 }
 
-func UpdatePlaintextAccessCredential(ctx context.Context, c *Client, id string, input *UpdateAccessCredentialInput) (*AccessCredential, error) {
+func UpdatePlaintextAccessCredential(ctx context.Context, c *Client, id string, input *UpdatePlaintextAccessCredentialInput) (*AccessCredential, error) {
 	path := fmt.Sprintf("%s/plaintext/%s", accessCredentialsEndpoint, id)
 	var result AccessCredential
 	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {
@@ -128,7 +136,7 @@ func UpdatePlaintextAccessCredential(ctx context.Context, c *Client, id string, 
 	return &result, nil
 }
 
-func UpdateKVAccessCredential(ctx context.Context, c *Client, id string, input *UpdateAccessCredentialInput) (*AccessCredential, error) {
+func UpdateKVAccessCredential(ctx context.Context, c *Client, id string, input *UpdateKVAccessCredentialInput) (*AccessCredential, error) {
 	path := fmt.Sprintf("%s/kv/%s", accessCredentialsEndpoint, id)
 	var result AccessCredential
 	if err := c.doRequest(ctx, http.MethodPatch, path, input, &result); err != nil {

--- a/internal/provider/acc_tests/common_test.go
+++ b/internal/provider/acc_tests/common_test.go
@@ -92,6 +92,33 @@ func checkSecretStoreID(resourceName string) resource.TestCheckFunc {
 	return resource.TestCheckResourceAttr(resourceName, "secret_store_id", mockSecretStoreID)
 }
 
+// recordID captures a resource's id so a later step can assert it was not recreated.
+func recordID(resourceName string, target *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		*target = rs.Primary.ID
+		return nil
+	}
+}
+
+// checkIDUnchanged asserts the resource still has the id captured by recordID,
+// i.e. it was updated in place rather than destroyed and recreated.
+func checkIDUnchanged(resourceName string, previous *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resourceName)
+		}
+		if rs.Primary.ID != *previous {
+			return fmt.Errorf("%s was recreated: id changed %s -> %s", resourceName, *previous, rs.Primary.ID)
+		}
+		return nil
+	}
+}
+
 func validateResourceDestroyed(resource, resourcePath string) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		c := provider.Meta().(*client.Client)

--- a/internal/provider/acc_tests/kv_access_credential_test.go
+++ b/internal/provider/acc_tests/kv_access_credential_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccResourceKVAccessCredential(t *testing.T) {
+	var id string
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      validateResourceDestroyed("kv_access_credential", "v1/access_credentials"),
@@ -22,6 +23,17 @@ func TestAccResourceKVAccessCredential(t *testing.T) {
 						"hush_kv_access_credential.test", "name", "test-kv-cred",
 					),
 					checkSecretStoreID("hush_kv_access_credential.test"),
+					recordID("hush_kv_access_credential.test", &id),
+				),
+			},
+			{
+				// Changing items is an in-place update, not a replacement.
+				Config: kvAccessCredentialStep2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"hush_kv_access_credential.test", "items.0.value", "xyz789",
+					),
+					checkIDUnchanged("hush_kv_access_credential.test", &id),
 				),
 			},
 		},
@@ -55,6 +67,19 @@ resource "hush_kv_access_credential" "test" {
   items {
     key   = "API_KEY"
     value = "abc123"
+  }
+}
+`
+
+const kvAccessCredentialStep2 = `
+resource "hush_kv_access_credential" "test" {
+  name            = "test-kv-cred"
+  deployment_ids  = ["` + mockDeploymentID + `"]
+  secret_store_id = "sst-mock-store-1"
+
+  items {
+    key   = "API_KEY"
+    value = "xyz789"
   }
 }
 `

--- a/internal/provider/acc_tests/plaintext_access_credential_test.go
+++ b/internal/provider/acc_tests/plaintext_access_credential_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestAccResourcePlaintextAccessCredential(t *testing.T) {
+	var id string
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      validateResourceDestroyed("plaintext_access_credential", "v1/access_credentials"),
@@ -22,6 +23,17 @@ func TestAccResourcePlaintextAccessCredential(t *testing.T) {
 						"hush_plaintext_access_credential.test", "name", "test-plaintext-cred",
 					),
 					checkSecretStoreID("hush_plaintext_access_credential.test"),
+					recordID("hush_plaintext_access_credential.test", &id),
+				),
+			},
+			{
+				// Rotating the secret is an in-place update, not a replacement.
+				Config: plaintextAccessCredentialStep2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"hush_plaintext_access_credential.test", "secret", "rotated-secret-value",
+					),
+					checkIDUnchanged("hush_plaintext_access_credential.test", &id),
 				),
 			},
 		},
@@ -52,6 +64,15 @@ resource "hush_plaintext_access_credential" "test" {
   deployment_ids  = ["` + mockDeploymentID + `"]
   secret_store_id = "sst-mock-store-1"
   secret          = "s3cr3t-value"
+}
+`
+
+const plaintextAccessCredentialStep2 = `
+resource "hush_plaintext_access_credential" "test" {
+  name            = "test-plaintext-cred"
+  deployment_ids  = ["` + mockDeploymentID + `"]
+  secret_store_id = "sst-mock-store-1"
+  secret          = "rotated-secret-value"
 }
 `
 

--- a/internal/provider/kv_access_credential/common.go
+++ b/internal/provider/kv_access_credential/common.go
@@ -62,7 +62,6 @@ func KVAccessCredentialResourceSchema() map[string]*schema.Schema {
 		Type:        schema.TypeList,
 		Required:    true,
 		MinItems:    1,
-		ForceNew:    true, // Items cannot be updated, requires recreation
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"key": {

--- a/internal/provider/kv_access_credential/resource.go
+++ b/internal/provider/kv_access_credential/resource.go
@@ -118,7 +118,7 @@ func kvAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	c := meta.(*client.Client)
 	id := d.Id()
 
-	input := &client.UpdateAccessCredentialInput{}
+	input := &client.UpdateKVAccessCredentialInput{}
 
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
@@ -133,6 +133,20 @@ func kvAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	if d.HasChange("secret_store_id") {
 		secretStoreID := d.Get("secret_store_id").(string)
 		input.SecretStoreID = &secretStoreID
+	}
+
+	if d.HasChange("items") {
+		items := make([]client.KVItem, 0)
+		if v, ok := d.GetOk("items"); ok {
+			for _, item := range v.([]any) {
+				itemMap := item.(map[string]any)
+				items = append(items, client.KVItem{
+					Key:   itemMap["key"].(string),
+					Value: itemMap["value"].(string),
+				})
+			}
+		}
+		input.Items = items
 	}
 
 	_, err := client.UpdateKVAccessCredential(ctx, c, id, input)

--- a/internal/provider/plaintext_access_credential/common.go
+++ b/internal/provider/plaintext_access_credential/common.go
@@ -61,7 +61,6 @@ func PlaintextAccessCredentialResourceSchema() map[string]*schema.Schema {
 		Type:          schema.TypeString,
 		Optional:      true,
 		Sensitive:     true,
-		ForceNew:      true, // Secret cannot be updated, requires recreation
 		ConflictsWith: []string{"secret_wo"},
 		ExactlyOneOf:  []string{"secret", "secret_wo"},
 	}
@@ -79,7 +78,6 @@ func PlaintextAccessCredentialResourceSchema() map[string]*schema.Schema {
 		Description:  secretWOVersionDesc,
 		Type:         schema.TypeString,
 		Optional:     true,
-		ForceNew:     true,
 		RequiredWith: []string{"secret_wo"},
 	}
 

--- a/internal/provider/plaintext_access_credential/resource.go
+++ b/internal/provider/plaintext_access_credential/resource.go
@@ -105,7 +105,7 @@ func plaintextAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData
 	c := meta.(*client.Client)
 	id := d.Id()
 
-	input := &client.UpdateAccessCredentialInput{}
+	input := &client.UpdatePlaintextAccessCredentialInput{}
 
 	if d.HasChange("name") {
 		name := d.Get("name").(string)
@@ -120,6 +120,11 @@ func plaintextAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData
 	if d.HasChange("secret_store_id") {
 		secretStoreID := d.Get("secret_store_id").(string)
 		input.SecretStoreID = &secretStoreID
+	}
+
+	if d.HasChange("secret") || d.HasChange("secret_wo") || d.HasChange("secret_wo_version") {
+		secret := writeonly.GetString(d, "secret", "secret_wo")
+		input.Secret = &secret
 	}
 
 	_, err := client.UpdatePlaintextAccessCredential(ctx, c, id, input)


### PR DESCRIPTION
## Summary

Rotating the secret of a static access credential is now an **in-place update**
instead of a destroy-and-recreate (fixes HUSH-6700).

Previously `secret`/`secret_wo_version` on `hush_plaintext_access_credential` and
`items` on `hush_kv_access_credential` were `ForceNew`, so changing them replaced
the credential and churned its id -- even though midgard's PATCH endpoints accept a
new secret (`PlaintextAccessCredentialChange.secret`) / items
(`KVAccessCredentialChange.items`) and re-encrypt in place, exactly as the dynamic
credentials already do.

## Changes

- Drop `ForceNew` from plaintext `secret`/`secret_wo_version` and kv `items`.
- Send the new value on update via per-kind inputs
  (`UpdatePlaintextAccessCredentialInput.Secret`, `UpdateKVAccessCredentialInput.Items`),
  replacing the shared `UpdateAccessCredentialInput`.
- Extend the plaintext and kv acceptance tests with an update step and a shared
  id-stability check that asserts the credential is updated, not recreated.

## Note for the reviewer

The acceptance-test update steps need the mock fixtures (`mock_api_fixtures.json`)
to actually run under `make test-acc`; they are compile-verified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
