### PR TITLE
HUSH-6698 client: paginate by-name/by-trigger data-source lookups

### DIFF
--- a/internal/client/access_credential.go
+++ b/internal/client/access_credential.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 )
 
 const accessCredentialsEndpoint = "/v1/access_credentials"
@@ -71,13 +70,6 @@ type UpdateKVAccessCredentialInput struct {
 	Description   *string              `json:"description,omitempty"`
 	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
 	Items         []KVItem             `json:"items,omitempty"`
-}
-
-type AccessCredentialListResponse struct {
-	Items      []AccessCredential `json:"items"`
-	Total      int                `json:"total"`
-	HasNext    bool               `json:"has_next"`
-	NextCursor *string            `json:"next_cursor"`
 }
 
 // secretStoreIDUpdate marshals to null when ID is empty (detaching the credential
@@ -175,23 +167,4 @@ func DeleteAccessCredential(ctx context.Context, c *Client, id string) error {
 		return err
 	}
 	return nil
-}
-
-func ListAccessCredentials(ctx context.Context, c *Client, credType *AccessCredentialType) (*AccessCredentialListResponse, error) {
-	params := url.Values{}
-	if credType != nil {
-		params.Set("type", string(*credType))
-	}
-
-	path := accessCredentialsEndpoint
-	if len(params) > 0 {
-		path += "?" + params.Encode()
-	}
-
-	var resp AccessCredentialListResponse
-	err := c.doRequest(ctx, http.MethodGet, path, nil, &resp)
-	if err != nil {
-		return nil, err
-	}
-	return &resp, nil
 }

--- a/internal/client/access_policy.go
+++ b/internal/client/access_policy.go
@@ -143,13 +143,6 @@ type UpdateAccessPolicyInput struct {
 	DeliveryConfig      any                     `json:"delivery_config,omitempty"`
 }
 
-type AccessPolicyListResponse struct {
-	Items      []AccessPolicy `json:"items"`
-	Total      int            `json:"total"`
-	HasNext    bool           `json:"has_next"`
-	NextCursor *string        `json:"next_cursor"`
-}
-
 func CreateAccessPolicy(ctx context.Context, c *Client, input *CreateAccessPolicyInput) (*AccessPolicy, error) {
 	var result AccessPolicy
 	if err := c.doRequest(ctx, http.MethodPost, accessPoliciesEndpoint, input, &result); err != nil {
@@ -192,12 +185,4 @@ func DeleteAccessPolicy(ctx context.Context, c *Client, id string) error {
 		return err
 	}
 	return nil
-}
-
-func ListAccessPolicies(ctx context.Context, c *Client) (*AccessPolicyListResponse, error) {
-	var resp AccessPolicyListResponse
-	if err := c.doRequest(ctx, http.MethodGet, accessPoliciesEndpoint, nil, &resp); err != nil {
-		return nil, err
-	}
-	return &resp, nil
 }

--- a/internal/client/aws_integration.go
+++ b/internal/client/aws_integration.go
@@ -105,13 +105,14 @@ func GetAWSIntegration(ctx context.Context, c *Client, id string) (*AWSIntegrati
 }
 
 func GetAWSIntegrationsByName(ctx context.Context, c *Client, name string) ([]AWSIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=aws", integrationsEndpoint, encodedName)
-	var resp AWSIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=aws", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]AWSIntegration, *string, error) {
+		var resp AWSIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateAWSIntegration(ctx context.Context, c *Client, id string, input *UpdateAWSIntegrationInput) (*AWSIntegration, error) {

--- a/internal/client/collectpages_internal_test.go
+++ b/internal/client/collectpages_internal_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// TestCollectPages covers the shared paging loop used by every by-name/by-trigger
+// lookup, independent of any endpoint: accumulation, cursor threading, both stop
+// conditions, and error propagation.
+func TestCollectPages(t *testing.T) {
+	sp := func(s string) *string { return &s }
+
+	t.Run("accumulates across pages and threads the cursor", func(t *testing.T) {
+		pages := []struct {
+			items []int
+			next  *string
+		}{
+			{[]int{1, 2}, sp("c1")},
+			{[]int{3, 4}, sp("c2")},
+			{[]int{5}, nil},
+		}
+		var seenCursors []string
+		i := 0
+		got, err := collectPages(func(cursor string) ([]int, *string, error) {
+			seenCursors = append(seenCursors, cursor)
+			p := pages[i]
+			i++
+			return p.items, p.next, nil
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []int{1, 2, 3, 4, 5}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("items = %v, want %v", got, want)
+		}
+		if want := []string{"", "c1", "c2"}; !reflect.DeepEqual(seenCursors, want) {
+			t.Fatalf("cursors passed = %v, want %v", seenCursors, want)
+		}
+	})
+
+	t.Run("stops on nil next", func(t *testing.T) {
+		calls := 0
+		got, err := collectPages(func(string) ([]int, *string, error) {
+			calls++
+			return []int{7}, nil, nil
+		})
+		if err != nil || calls != 1 || !reflect.DeepEqual(got, []int{7}) {
+			t.Fatalf("got %v, err %v, calls %d", got, err, calls)
+		}
+	})
+
+	t.Run("stops on empty-string next", func(t *testing.T) {
+		calls := 0
+		got, err := collectPages(func(string) ([]int, *string, error) {
+			calls++
+			return []int{8}, sp(""), nil
+		})
+		if err != nil || calls != 1 || !reflect.DeepEqual(got, []int{8}) {
+			t.Fatalf("got %v, err %v, calls %d", got, err, calls)
+		}
+	})
+
+	t.Run("propagates fetch error", func(t *testing.T) {
+		sentinel := errors.New("boom")
+		_, err := collectPages(func(string) ([]int, *string, error) {
+			return nil, nil, sentinel
+		})
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("err = %v, want %v", err, sentinel)
+		}
+	})
+}
+
+// TestWithCursor covers the query-append edge that the by-name lookups rely on:
+// a filtered path (name=/type=) must gain the cursor with & , a bare path with ?,
+// and the cursor must be escaped.
+func TestWithCursor(t *testing.T) {
+	cases := []struct {
+		name, path, cursor, want string
+	}{
+		{"empty cursor unchanged", "/v1/deployments?name=x", "", "/v1/deployments?name=x"},
+		{"appends with & when query present", "/v1/integrations?name=x&type=gitlab", "c1", "/v1/integrations?name=x&type=gitlab&cursor=c1"},
+		{"appends with ? when no query", "/v1/deployments", "c1", "/v1/deployments?cursor=c1"},
+		{"escapes the cursor", "/v1/x?y=1", "a b/c", "/v1/x?y=1&cursor=a+b%2Fc"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := withCursor(tc.path, tc.cursor); got != tc.want {
+				t.Fatalf("withCursor(%q, %q) = %q, want %q", tc.path, tc.cursor, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/client/deployment.go
+++ b/internal/client/deployment.go
@@ -121,23 +121,20 @@ func DeleteDeployment(ctx context.Context, c *Client, id string) error {
 
 // DeploymentListResponse represents the response from listing deployments
 type DeploymentListResponse struct {
-	Items      []Deployment `json:"items"`
-	NextCursor *string      `json:"next_cursor"`
-	HasMore    bool         `json:"has_more"`
+	Items    []Deployment `json:"items"`
+	NextPage *string      `json:"next_page"`
 }
 
-// GetDeploymentsByName retrieves deployments by name
+// GetDeploymentsByName retrieves all deployments matching name, following pagination.
 func GetDeploymentsByName(ctx context.Context, c *Client, name string) ([]Deployment, error) {
-	// URL encode the name parameter to handle special characters
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s", deploymentsEndpoint, encodedName)
-
-	var resp DeploymentListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s", deploymentsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]Deployment, *string, error) {
+		var resp DeploymentListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 // AccessBridgeStatus represents the response from the access_bridge endpoint

--- a/internal/client/gcp_integration.go
+++ b/internal/client/gcp_integration.go
@@ -102,13 +102,14 @@ func GetGCPIntegration(ctx context.Context, c *Client, id string) (*GCPIntegrati
 }
 
 func GetGCPIntegrationsByName(ctx context.Context, c *Client, name string) ([]GCPIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=gcp", integrationsEndpoint, encodedName)
-	var resp GCPIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=gcp", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]GCPIntegration, *string, error) {
+		var resp GCPIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateGCPIntegration(ctx context.Context, c *Client, id string, input *UpdateGCPIntegrationInput) (*GCPIntegration, error) {

--- a/internal/client/integration.go
+++ b/internal/client/integration.go
@@ -97,13 +97,14 @@ func GetGitlabIntegration(ctx context.Context, c *Client, id string) (*GitlabInt
 }
 
 func GetGitlabIntegrationsByName(ctx context.Context, c *Client, name string) ([]GitlabIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=gitlab", integrationsEndpoint, encodedName)
-	var resp GitlabIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=gitlab", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]GitlabIntegration, *string, error) {
+		var resp GitlabIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateGitlabIntegration(ctx context.Context, c *Client, id string, input *UpdateGitlabIntegrationInput) (*GitlabIntegration, error) {
@@ -187,13 +188,14 @@ func GetConfluenceIntegration(ctx context.Context, c *Client, id string) (*Confl
 }
 
 func GetConfluenceIntegrationsByName(ctx context.Context, c *Client, name string) ([]ConfluenceIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=confluence", integrationsEndpoint, encodedName)
-	var resp ConfluenceIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=confluence", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]ConfluenceIntegration, *string, error) {
+		var resp ConfluenceIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateConfluenceIntegration(ctx context.Context, c *Client, id string, input *UpdateConfluenceIntegrationInput) (*ConfluenceIntegration, error) {
@@ -282,13 +284,14 @@ func GetJiraIntegration(ctx context.Context, c *Client, id string) (*JiraIntegra
 }
 
 func GetJiraIntegrationsByName(ctx context.Context, c *Client, name string) ([]JiraIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=jira", integrationsEndpoint, encodedName)
-	var resp JiraIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=jira", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]JiraIntegration, *string, error) {
+		var resp JiraIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateJiraIntegration(ctx context.Context, c *Client, id string, input *UpdateJiraIntegrationInput) (*JiraIntegration, error) {
@@ -375,13 +378,14 @@ func GetBitbucketIntegration(ctx context.Context, c *Client, id string) (*Bitbuc
 }
 
 func GetBitbucketIntegrationsByName(ctx context.Context, c *Client, name string) ([]BitbucketIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=bitbucket", integrationsEndpoint, encodedName)
-	var resp BitbucketIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=bitbucket", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]BitbucketIntegration, *string, error) {
+		var resp BitbucketIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateBitbucketIntegration(ctx context.Context, c *Client, id string, input *UpdateBitbucketIntegrationInput) (*BitbucketIntegration, error) {
@@ -466,13 +470,14 @@ func GetInfisicalIntegration(ctx context.Context, c *Client, id string) (*Infisi
 }
 
 func GetInfisicalIntegrationsByName(ctx context.Context, c *Client, name string) ([]InfisicalIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=infisical", integrationsEndpoint, encodedName)
-	var resp InfisicalIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=infisical", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]InfisicalIntegration, *string, error) {
+		var resp InfisicalIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateInfisicalIntegration(ctx context.Context, c *Client, id string, input *UpdateInfisicalIntegrationInput) (*InfisicalIntegration, error) {
@@ -563,13 +568,14 @@ func GetSonatypeIntegration(ctx context.Context, c *Client, id string) (*Sonatyp
 }
 
 func GetSonatypeIntegrationsByName(ctx context.Context, c *Client, name string) ([]SonatypeIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=sonatype", integrationsEndpoint, encodedName)
-	var resp SonatypeIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=sonatype", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]SonatypeIntegration, *string, error) {
+		var resp SonatypeIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateSonatypeIntegration(ctx context.Context, c *Client, id string, input *UpdateSonatypeIntegrationInput) (*SonatypeIntegration, error) {
@@ -658,13 +664,14 @@ func GetArtifactoryIntegration(ctx context.Context, c *Client, id string) (*Arti
 }
 
 func GetArtifactoryIntegrationsByName(ctx context.Context, c *Client, name string) ([]ArtifactoryIntegration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s&type=artifactory", integrationsEndpoint, encodedName)
-	var resp ArtifactoryIntegrationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s&type=artifactory", integrationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]ArtifactoryIntegration, *string, error) {
+		var resp ArtifactoryIntegrationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func UpdateArtifactoryIntegration(ctx context.Context, c *Client, id string, input *UpdateArtifactoryIntegrationInput) (*ArtifactoryIntegration, error) {

--- a/internal/client/notification_channel.go
+++ b/internal/client/notification_channel.go
@@ -134,17 +134,3 @@ func GetNotificationChannelsByName(ctx context.Context, c *Client, name string) 
 		return resp.Items, resp.NextPage, nil
 	})
 }
-
-func ListNotificationChannels(ctx context.Context, c *Client, enabled *bool) ([]NotificationChannel, error) {
-	path := notificationChannelsEndpoint
-	if enabled != nil {
-		path = fmt.Sprintf("%s?enabled=%t", path, *enabled)
-	}
-
-	var resp NotificationChannelListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
-}

--- a/internal/client/notification_channel.go
+++ b/internal/client/notification_channel.go
@@ -120,21 +120,19 @@ func DeleteNotificationChannel(ctx context.Context, c *Client, id string) error 
 }
 
 type NotificationChannelListResponse struct {
-	Items      []NotificationChannel `json:"items"`
-	NextCursor *string               `json:"next_cursor"`
-	HasMore    bool                  `json:"has_more"`
+	Items    []NotificationChannel `json:"items"`
+	NextPage *string               `json:"next_page"`
 }
 
 func GetNotificationChannelsByName(ctx context.Context, c *Client, name string) ([]NotificationChannel, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s", notificationChannelsEndpoint, encodedName)
-
-	var resp NotificationChannelListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s", notificationChannelsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]NotificationChannel, *string, error) {
+		var resp NotificationChannelListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func ListNotificationChannels(ctx context.Context, c *Client, enabled *bool) ([]NotificationChannel, error) {

--- a/internal/client/notification_configuration.go
+++ b/internal/client/notification_configuration.go
@@ -91,25 +91,23 @@ func DeleteNotificationConfiguration(ctx context.Context, c *Client, id string) 
 }
 
 type NotificationConfigurationListResponse struct {
-	Items      []NotificationConfiguration `json:"items"`
-	NextCursor *string                     `json:"next_cursor"`
-	HasMore    bool                        `json:"has_more"`
+	Items    []NotificationConfiguration `json:"items"`
+	NextPage *string                     `json:"next_page"`
 }
 
 func GetNotificationConfigurationsByName(ctx context.Context, c *Client, name string) ([]NotificationConfiguration, error) {
-	encodedName := url.QueryEscape(name)
-	path := fmt.Sprintf("%s?name=%s", notificationConfigurationsEndpoint, encodedName)
-
-	var resp NotificationConfigurationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
+	base := fmt.Sprintf("%s?name=%s", notificationConfigurationsEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]NotificationConfiguration, *string, error) {
+		var resp NotificationConfigurationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func ListNotificationConfigurations(ctx context.Context, c *Client, enabled *bool, trigger *Trigger, aggregation *AggregationDuration) ([]NotificationConfiguration, error) {
-	path := notificationConfigurationsEndpoint
+	base := notificationConfigurationsEndpoint
 	params := url.Values{}
 
 	if enabled != nil {
@@ -123,15 +121,16 @@ func ListNotificationConfigurations(ctx context.Context, c *Client, enabled *boo
 	}
 
 	if len(params) > 0 {
-		path = fmt.Sprintf("%s?%s", path, params.Encode())
+		base = fmt.Sprintf("%s?%s", base, params.Encode())
 	}
 
-	var resp NotificationConfigurationListResponse
-	if err := c.doRequest(ctx, http.MethodGet, path, nil, &resp); err != nil {
-		return nil, err
-	}
-
-	return resp.Items, nil
+	return collectPages(func(cursor string) ([]NotificationConfiguration, *string, error) {
+		var resp NotificationConfigurationListResponse
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &resp); err != nil {
+			return nil, nil, err
+		}
+		return resp.Items, resp.NextPage, nil
+	})
 }
 
 func GetNotificationConfigurationsByTrigger(ctx context.Context, c *Client, trigger string) ([]NotificationConfiguration, error) {

--- a/internal/client/pagination.go
+++ b/internal/client/pagination.go
@@ -1,0 +1,43 @@
+package client
+
+import (
+	"net/url"
+	"strings"
+)
+
+// collectPages follows a cursor-paginated list endpoint and returns the
+// concatenated items across every page. fetchPage is called once per page with
+// the cursor for the page to fetch (empty on the first request) and returns that
+// page's items and the cursor for the next page (nil/empty when exhausted).
+//
+// The backend uses hush.pagination.CursorPage everywhere: the request carries a
+// `cursor` query parameter and each response reports the next page in `next_page`.
+func collectPages[T any](fetchPage func(cursor string) (items []T, next *string, err error)) ([]T, error) {
+	var all []T
+	cursor := ""
+	for {
+		items, next, err := fetchPage(cursor)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, items...)
+		if next == nil || *next == "" {
+			break
+		}
+		cursor = *next
+	}
+	return all, nil
+}
+
+// withCursor appends the pagination cursor to a list path that may already carry
+// filter query parameters.
+func withCursor(path, cursor string) string {
+	if cursor == "" {
+		return path
+	}
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	return path + sep + "cursor=" + url.QueryEscape(cursor)
+}

--- a/internal/client/pagination_test.go
+++ b/internal/client/pagination_test.go
@@ -1,0 +1,150 @@
+package client_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+	"github.com/hushsecurity/terraform-provider-hush/internal/testutil"
+)
+
+// newPagedClient returns a client wired to a mock whose single list endpoint
+// pages with the given size, so by-name lookups must follow next_page.
+func newPagedClient(t *testing.T, endpoint string, pageSize int) (*client.Client, *testutil.MockServer) {
+	t.Helper()
+	ms := testutil.NewMockServer(&testutil.Fixtures{
+		Endpoints: map[string]map[string]any{endpoint: {}},
+	})
+	t.Cleanup(ms.Close)
+	ms.SetPageSize(pageSize)
+	c, err := client.NewClient(context.Background(), "mock-id", "mock-secret", ms.URL())
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c, ms
+}
+
+// TestGetDeploymentsByName_FollowsPagination proves collectPages walks every page
+// of a cursor-paginated response across the interesting count boundaries. With
+// the mock page size set to 2, any count above 2 forces the by-name lookup to
+// follow next_page; before HUSH-6698 only the first page was read.
+func TestGetDeploymentsByName_FollowsPagination(t *testing.T) {
+	c, ms := newPagedClient(t, "GET /v1/deployments", 2)
+
+	// A decoy under a different name guards against the server-side name filter
+	// leaking unrelated rows into a paged result.
+	ms.SeedObject("deployments", "dep-decoy", map[string]any{"id": "dep-decoy", "name": "decoy"})
+
+	ctx := context.Background()
+	// Cover single page, an exactly-full page, an exact multiple, and remainders.
+	for _, total := range []int{1, 2, 4, 5, 7} {
+		name := fmt.Sprintf("dup-%d", total)
+		for i := 0; i < total; i++ {
+			id := fmt.Sprintf("dep-%s-%02d", name, i)
+			ms.SeedObject("deployments", id, map[string]any{"id": id, "name": name})
+		}
+
+		got, err := client.GetDeploymentsByName(ctx, c, name)
+		if err != nil {
+			t.Fatalf("GetDeploymentsByName(%q): %v", name, err)
+		}
+		if len(got) != total {
+			t.Errorf("name %q: expected %d deployments across pages, got %d", name, total, len(got))
+		}
+		for _, d := range got {
+			if d.Name != name {
+				t.Errorf("name %q: filter leaked deployment %q (%s)", name, d.Name, d.ID)
+			}
+		}
+	}
+}
+
+// countFn adapts a typed by-name lookup to (count, error) so every lookup can be
+// exercised by one table.
+type countFn func(context.Context, *client.Client, string) (int, error)
+
+func adapt[T any](fn func(context.Context, *client.Client, string) ([]T, error)) countFn {
+	return func(ctx context.Context, c *client.Client, v string) (int, error) {
+		xs, err := fn(ctx, c, v)
+		return len(xs), err
+	}
+}
+
+// TestByNameLookups_FollowPagination exercises every paginated by-name/by-trigger
+// lookup end-to-end: each must collect all matches across pages (page size 2) and
+// keep excluding a decoy that shares the filter value. This catches per-lookup
+// wiring mistakes -- wrong endpoint, wrong type= filter, or a wrong next_page tag
+// on the list response -- that the shared collectPages unit test cannot.
+func TestByNameLookups_FollowPagination(t *testing.T) {
+	cases := []tableCase{
+		{"gitlab integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "gitlab"}, integDecoy, adapt(client.GetGitlabIntegrationsByName)},
+		{"confluence integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "confluence"}, integDecoy, adapt(client.GetConfluenceIntegrationsByName)},
+		{"jira integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "jira"}, integDecoy, adapt(client.GetJiraIntegrationsByName)},
+		{"bitbucket integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "bitbucket"}, integDecoy, adapt(client.GetBitbucketIntegrationsByName)},
+		{"infisical integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "infisical"}, integDecoy, adapt(client.GetInfisicalIntegrationsByName)},
+		{"sonatype integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "sonatype"}, integDecoy, adapt(client.GetSonatypeIntegrationsByName)},
+		{"artifactory integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "artifactory"}, integDecoy, adapt(client.GetArtifactoryIntegrationsByName)},
+		{"aws integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "aws"}, integDecoy, adapt(client.GetAWSIntegrationsByName)},
+		{"gcp integration", "GET /v1/integrations", "integrations", "name",
+			map[string]any{"type": "gcp"}, integDecoy, adapt(client.GetGCPIntegrationsByName)},
+		{"deployment", "GET /v1/deployments", "deployments", "name",
+			nil, nameDecoy, adapt(client.GetDeploymentsByName)},
+		{"notification channel", "GET /v1/notification_channels", "notification_channels", "name",
+			nil, nameDecoy, adapt(client.GetNotificationChannelsByName)},
+		{"notification configuration by name", "GET /v1/notification_configurations", "notification_configurations", "name",
+			nil, nameDecoy, adapt(client.GetNotificationConfigurationsByName)},
+		{"notification configuration by trigger", "GET /v1/notification_configurations", "notification_configurations", "trigger",
+			nil, map[string]any{"id": "decoy", "trigger": "other"}, adapt(client.GetNotificationConfigurationsByTrigger)},
+		{"secret store", "GET /v1/secret_stores", "secret_stores", "name",
+			nil, nameDecoy, adapt(client.GetSecretStoresByName)},
+	}
+
+	const total = 5 // > page size, so results span multiple pages
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			c, ms := newPagedClient(t, tc.endpoint, 2)
+			for i := 0; i < total; i++ {
+				id := fmt.Sprintf("row-%02d", i)
+				obj := map[string]any{"id": id, tc.filterKey: "dup"}
+				for k, v := range tc.itemFields {
+					obj[k] = v
+				}
+				ms.SeedObject(tc.store, id, obj)
+			}
+			ms.SeedObject(tc.store, fmt.Sprintf("%v", tc.decoy["id"]), tc.decoy)
+
+			n, err := tc.lookup(context.Background(), c, "dup")
+			if err != nil {
+				t.Fatalf("%s: lookup: %v", tc.label, err)
+			}
+			if n != total {
+				t.Fatalf("%s: expected %d across pages (decoy excluded), got %d", tc.label, total, n)
+			}
+		})
+	}
+}
+
+type tableCase struct {
+	label      string
+	endpoint   string
+	store      string
+	filterKey  string         // "name" or "trigger"
+	itemFields map[string]any // extra fields on matching rows (e.g. type)
+	decoy      map[string]any // a row that shares the filter value but must be excluded
+	lookup     countFn
+}
+
+// nameDecoy differs by name; integDecoy shares the name but differs by type.
+var (
+	nameDecoy  = map[string]any{"id": "decoy", "name": "other"}
+	integDecoy = map[string]any{"id": "decoy", "name": "dup", "type": "other"}
+)

--- a/internal/client/secret_store.go
+++ b/internal/client/secret_store.go
@@ -104,23 +104,12 @@ func DeleteSecretStore(ctx context.Context, c *Client, id string) error {
 // backend's server-side name filter and paging through every result. Names are not
 // unique, so this may return more than one store.
 func GetSecretStoresByName(ctx context.Context, c *Client, name string) ([]SecretStore, error) {
-	encodedName := url.QueryEscape(name)
-	var matches []SecretStore
-	cursor := ""
-	for {
-		path := fmt.Sprintf("%s?name=%s", secretStoresEndpoint, encodedName)
-		if cursor != "" {
-			path += "&cursor=" + url.QueryEscape(cursor)
-		}
+	base := fmt.Sprintf("%s?name=%s", secretStoresEndpoint, url.QueryEscape(name))
+	return collectPages(func(cursor string) ([]SecretStore, *string, error) {
 		var page SecretStoreListResponse
-		if err := c.doRequest(ctx, http.MethodGet, path, nil, &page); err != nil {
-			return nil, err
+		if err := c.doRequest(ctx, http.MethodGet, withCursor(base, cursor), nil, &page); err != nil {
+			return nil, nil, err
 		}
-		matches = append(matches, page.Items...)
-		if page.NextPage == nil || *page.NextPage == "" {
-			break
-		}
-		cursor = *page.NextPage
-	}
-	return matches, nil
+		return page.Items, page.NextPage, nil
+	})
 }

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 )
@@ -45,6 +47,7 @@ type MockServer struct {
 	routes   []route
 	hooks    map[string]map[Operation][]HookFunc
 	fixtures *Fixtures
+	pageSize int // when > 0, list responses are paginated with this page size
 	mu       sync.RWMutex
 }
 
@@ -65,6 +68,15 @@ func (ms *MockServer) URL() string { return ms.Server.URL }
 
 // Close shuts down the mock server.
 func (ms *MockServer) Close() { ms.Server.Close() }
+
+// SetPageSize enables cursor pagination of list responses with the given page
+// size. Zero (the default) disables it: a list returns every match in one page,
+// as before.
+func (ms *MockServer) SetPageSize(n int) {
+	ms.mu.Lock()
+	defer ms.mu.Unlock()
+	ms.pageSize = n
+}
 
 // SeedObject inserts a pre-existing object into the mock store.
 // Useful for resources that require pre-existing data (e.g., predefined configs).
@@ -220,12 +232,42 @@ func (ms *MockServer) handleList(w http.ResponseWriter, r *http.Request, storeKe
 		items = []any{}
 	}
 
+	total := len(items)
+	var nextPage *string
+	if ms.pageSize > 0 {
+		// Stable order so cursor offsets are consistent across pages; map
+		// iteration order is otherwise random.
+		sort.Slice(items, func(i, j int) bool {
+			return fmt.Sprintf("%v", items[i].(map[string]any)["id"]) <
+				fmt.Sprintf("%v", items[j].(map[string]any)["id"])
+		})
+		start := 0
+		if cur := r.URL.Query().Get("cursor"); cur != "" {
+			if n, err := strconv.Atoi(cur); err == nil && n > 0 {
+				start = n
+			}
+		}
+		if start > len(items) {
+			start = len(items)
+		}
+		end := start + ms.pageSize
+		if end > len(items) {
+			end = len(items)
+		}
+		if end < len(items) {
+			np := strconv.Itoa(end)
+			nextPage = &np
+		}
+		items = items[start:end]
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"items":    items,
-		"total":    len(items),
-		"has_more": false,
-		"has_next": false,
+		"items":     items,
+		"total":     total,
+		"next_page": nextPage,
+		"has_more":  nextPage != nil,
+		"has_next":  nextPage != nil,
 	})
 }
 
@@ -304,7 +346,7 @@ func (ms *MockServer) runHooks(resourceKey string, op Operation, obj map[string]
 
 func (ms *MockServer) matchesFilters(obj map[string]any, params map[string][]string) bool {
 	for key, values := range params {
-		if len(values) == 0 {
+		if key == "cursor" || len(values) == 0 {
 			continue
 		}
 		val := fmt.Sprintf("%v", obj[key])


### PR DESCRIPTION
The `*ByName` lookups (integrations, deployments, notification channels and
configurations) and `GetNotificationConfigurationsByTrigger` read only the first
page of a cursor-paginated response, so a name or trigger whose matches span more
than one page was silently truncated -- which can bypass the data sources'
"exactly one match" guard.

## Changes

- **Page the lookups.** Add a shared `collectPages`/`withCursor` helper and follow
  `next_page` on every by-name and by-trigger lookup. Correct the deployment and
  notification list responses, which were mismodeled with a never-populated
  `next_cursor`/`has_more`, to `next_page` (the backend uses
  `hush.pagination.CursorPage` uniformly).
- **Drop dead code.** Remove the unused `ListNotificationChannels`,
  `ListAccessCredentials`, and `ListAccessPolicies` -- no callers, and there is no
  by-name lookup for access credentials or policies -- and their mismodeled
  response structs.
- **Unify secret stores.** Route `GetSecretStoresByName`, which hand-rolled the
  same loop, through the shared helper.
- **Cover the loop.** Give the mock server opt-in cursor pagination (off by
  default) so the paging loop is actually exercised, and add unit tests for
  `collectPages`/`withCursor` plus a table that drives every by-name and by-trigger
  lookup across multiple pages.

For callers the only behavior change is that a by-name/by-trigger lookup now
returns the complete result set instead of just the first page.
