### PR TITLE
HUSH-6652 access_credential: detach secret store with explicit null

### DIFF
--- a/internal/client/access_credential.go
+++ b/internal/client/access_credential.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -59,17 +60,17 @@ type CreateKVAccessCredentialInput struct {
 }
 
 type UpdatePlaintextAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	Secret        *string `json:"secret,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Secret        *string              `json:"secret,omitempty"`
 }
 
 type UpdateKVAccessCredentialInput struct {
-	Name          *string  `json:"name,omitempty"`
-	Description   *string  `json:"description,omitempty"`
-	SecretStoreID *string  `json:"secret_store_id,omitempty"`
-	Items         []KVItem `json:"items,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Items         []KVItem             `json:"items,omitempty"`
 }
 
 type AccessCredentialListResponse struct {
@@ -77,6 +78,28 @@ type AccessCredentialListResponse struct {
 	Total      int                `json:"total"`
 	HasNext    bool               `json:"has_next"`
 	NextCursor *string            `json:"next_cursor"`
+}
+
+// secretStoreIDUpdate marshals to null when ID is empty (detaching the credential
+// from its secret store) and to the id otherwise. A nil wrapper on an update input
+// is omitted, meaning no change. secret_store_id needs three states on update --
+// omitted (unchanged), an id (re-point), and explicit null (detach) -- which
+// omitempty on a plain *string cannot express: a pointer to "" marshals as "",
+// which midgard rejects (the field must be a valid sst- id or null). This mirrors
+// oidcProviderUpdate in deployment.go.
+type secretStoreIDUpdate struct{ ID string }
+
+func (s secretStoreIDUpdate) MarshalJSON() ([]byte, error) {
+	if s.ID == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(s.ID)
+}
+
+// NewSecretStoreIDUpdate wraps a secret_store_id (empty to detach) for an update
+// request, forcing the secret_store_id field to be sent.
+func NewSecretStoreIDUpdate(id string) *secretStoreIDUpdate {
+	return &secretStoreIDUpdate{ID: id}
 }
 
 func CreatePlaintextAccessCredential(ctx context.Context, c *Client, input *CreatePlaintextAccessCredentialInput) (*AccessCredential, error) {

--- a/internal/client/access_credential_test.go
+++ b/internal/client/access_credential_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestUpdateInput_SecretStoreIDMarshaling verifies the three update states of
+// secret_store_id: omitted when unchanged, explicit null when detached, and the
+// id when re-pointed. midgard rejects "" (the field must be a valid sst- id or
+// null), so detaching must send null rather than an empty string.
+func TestUpdateInput_SecretStoreIDMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    UpdatePlaintextAccessCredentialInput
+		contains string
+		omits    bool
+	}{
+		{
+			name:  "unchanged omits the field",
+			input: UpdatePlaintextAccessCredentialInput{},
+			omits: true,
+		},
+		{
+			name:     "detach sends explicit null",
+			input:    UpdatePlaintextAccessCredentialInput{SecretStoreID: NewSecretStoreIDUpdate("")},
+			contains: `"secret_store_id":null`,
+		},
+		{
+			name:     "set sends the id",
+			input:    UpdatePlaintextAccessCredentialInput{SecretStoreID: NewSecretStoreIDUpdate("sst-abc123")},
+			contains: `"secret_store_id":"sst-abc123"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			got := string(b)
+			if tc.omits {
+				if strings.Contains(got, "secret_store_id") {
+					t.Fatalf("expected secret_store_id to be omitted, got %s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.contains) {
+				t.Fatalf("expected %s to contain %s", got, tc.contains)
+			}
+		})
+	}
+}

--- a/internal/client/dynamic_access_credential.go
+++ b/internal/client/dynamic_access_credential.go
@@ -70,16 +70,16 @@ type CreatePostgresAccessCredentialInput struct {
 }
 
 type UpdatePostgresAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	DBName        *string `json:"db_name,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	Port          *int    `json:"port,omitempty"`
-	SSLMode       *string `json:"ssl_mode,omitempty"`
-	SSLCA         *string `json:"ssl_ca,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DBName        *string              `json:"db_name,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	Port          *int                 `json:"port,omitempty"`
+	SSLMode       *string              `json:"ssl_mode,omitempty"`
+	SSLCA         *string              `json:"ssl_ca,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
 }
 
 func CreatePostgresAccessCredential(ctx context.Context, c *Client, input *CreatePostgresAccessCredentialInput) (*PostgresAccessCredential, error) {
@@ -156,17 +156,17 @@ type CreateMongoDBAccessCredentialInput struct {
 }
 
 type UpdateMongoDBAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	DBName        *string `json:"db_name,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	Port          *int    `json:"port,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
-	AuthSource    *string `json:"auth_source,omitempty"`
-	TLS           *bool   `json:"tls,omitempty"`
-	TLSCA         *string `json:"tls_ca,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DBName        *string              `json:"db_name,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	Port          *int                 `json:"port,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
+	AuthSource    *string              `json:"auth_source,omitempty"`
+	TLS           *bool                `json:"tls,omitempty"`
+	TLSCA         *string              `json:"tls_ca,omitempty"`
 }
 
 func CreateMongoDBAccessCredential(ctx context.Context, c *Client, input *CreateMongoDBAccessCredentialInput) (*MongoDBAccessCredential, error) {
@@ -240,16 +240,16 @@ type CreateMongoDBAtlasAccessCredentialInput struct {
 }
 
 type UpdateMongoDBAtlasAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	GroupID       *string `json:"group_id,omitempty"`
-	DBName        *string `json:"db_name,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	ClientID      *string `json:"client_id,omitempty"`
-	ClientSecret  *string `json:"client_secret,omitempty"`
-	PublicKey     *string `json:"public_key,omitempty"`
-	PrivateKey    *string `json:"private_key,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	GroupID       *string              `json:"group_id,omitempty"`
+	DBName        *string              `json:"db_name,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	ClientID      *string              `json:"client_id,omitempty"`
+	ClientSecret  *string              `json:"client_secret,omitempty"`
+	PublicKey     *string              `json:"public_key,omitempty"`
+	PrivateKey    *string              `json:"private_key,omitempty"`
 }
 
 func CreateMongoDBAtlasAccessCredential(ctx context.Context, c *Client, input *CreateMongoDBAtlasAccessCredentialInput) (*MongoDBAtlasAccessCredential, error) {
@@ -324,16 +324,16 @@ type CreateMySQLAccessCredentialInput struct {
 }
 
 type UpdateMySQLAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	DBName        *string `json:"db_name,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	Port          *int    `json:"port,omitempty"`
-	SSLMode       *string `json:"ssl_mode,omitempty"`
-	SSLCA         *string `json:"ssl_ca,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DBName        *string              `json:"db_name,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	Port          *int                 `json:"port,omitempty"`
+	SSLMode       *string              `json:"ssl_mode,omitempty"`
+	SSLCA         *string              `json:"ssl_ca,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
 }
 
 func CreateMySQLAccessCredential(ctx context.Context, c *Client, input *CreateMySQLAccessCredentialInput) (*MySQLAccessCredential, error) {
@@ -408,16 +408,16 @@ type CreateMariaDBAccessCredentialInput struct {
 }
 
 type UpdateMariaDBAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	DBName        *string `json:"db_name,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	Port          *int    `json:"port,omitempty"`
-	SSLMode       *string `json:"ssl_mode,omitempty"`
-	SSLCA         *string `json:"ssl_ca,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DBName        *string              `json:"db_name,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	Port          *int                 `json:"port,omitempty"`
+	SSLMode       *string              `json:"ssl_mode,omitempty"`
+	SSLCA         *string              `json:"ssl_ca,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
 }
 
 func CreateMariaDBAccessCredential(ctx context.Context, c *Client, input *CreateMariaDBAccessCredentialInput) (*MariaDBAccessCredential, error) {
@@ -482,11 +482,11 @@ type CreateOpenAIAccessCredentialInput struct {
 }
 
 type UpdateOpenAIAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	APIKey        *string `json:"api_key,omitempty"`
-	ProjectID     *string `json:"project_id,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	APIKey        *string              `json:"api_key,omitempty"`
+	ProjectID     *string              `json:"project_id,omitempty"`
 }
 
 func CreateOpenAIAccessCredential(ctx context.Context, c *Client, input *CreateOpenAIAccessCredentialInput) (*OpenAIAccessCredential, error) {
@@ -551,11 +551,11 @@ type CreateGeminiAccessCredentialInput struct {
 }
 
 type UpdateGeminiAccessCredentialInput struct {
-	Name              *string `json:"name,omitempty"`
-	Description       *string `json:"description,omitempty"`
-	SecretStoreID     *string `json:"secret_store_id,omitempty"`
-	ServiceAccountKey *string `json:"service_account_key,omitempty"`
-	ProjectID         *string `json:"project_id,omitempty"`
+	Name              *string              `json:"name,omitempty"`
+	Description       *string              `json:"description,omitempty"`
+	SecretStoreID     *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	ServiceAccountKey *string              `json:"service_account_key,omitempty"`
+	ProjectID         *string              `json:"project_id,omitempty"`
 }
 
 func CreateGeminiAccessCredential(ctx context.Context, c *Client, input *CreateGeminiAccessCredentialInput) (*GeminiAccessCredential, error) {
@@ -620,11 +620,11 @@ type CreateGrokAccessCredentialInput struct {
 }
 
 type UpdateGrokAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	APIKey        *string `json:"api_key,omitempty"`
-	TeamID        *string `json:"team_id,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	APIKey        *string              `json:"api_key,omitempty"`
+	TeamID        *string              `json:"team_id,omitempty"`
 }
 
 func CreateGrokAccessCredential(ctx context.Context, c *Client, input *CreateGrokAccessCredentialInput) (*GrokAccessCredential, error) {
@@ -722,21 +722,21 @@ type CreateRedisAccessCredentialInput struct {
 // UpdateRedisAccessCredentialInput omits engine: it is immutable and ignored by
 // the API on update.
 type UpdateRedisAccessCredentialInput struct {
-	Name            *string `json:"name,omitempty"`
-	Description     *string `json:"description,omitempty"`
-	SecretStoreID   *string `json:"secret_store_id,omitempty"`
-	Host            *string `json:"host,omitempty"`
-	Port            *int    `json:"port,omitempty"`
-	Username        *string `json:"username,omitempty"`
-	Password        *string `json:"password,omitempty"`
-	Database        *int    `json:"database,omitempty"`
-	TLS             *bool   `json:"tls,omitempty"`
-	TLSCA           *string `json:"tls_ca,omitempty"`
-	CacheEngine     *string `json:"cache_engine,omitempty"`
-	Region          *string `json:"region,omitempty"`
-	UserGroupID     *string `json:"user_group_id,omitempty"`
-	AccessKeyID     *string `json:"access_key_id,omitempty"`
-	SecretAccessKey *string `json:"secret_access_key,omitempty"`
+	Name            *string              `json:"name,omitempty"`
+	Description     *string              `json:"description,omitempty"`
+	SecretStoreID   *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Host            *string              `json:"host,omitempty"`
+	Port            *int                 `json:"port,omitempty"`
+	Username        *string              `json:"username,omitempty"`
+	Password        *string              `json:"password,omitempty"`
+	Database        *int                 `json:"database,omitempty"`
+	TLS             *bool                `json:"tls,omitempty"`
+	TLSCA           *string              `json:"tls_ca,omitempty"`
+	CacheEngine     *string              `json:"cache_engine,omitempty"`
+	Region          *string              `json:"region,omitempty"`
+	UserGroupID     *string              `json:"user_group_id,omitempty"`
+	AccessKeyID     *string              `json:"access_key_id,omitempty"`
+	SecretAccessKey *string              `json:"secret_access_key,omitempty"`
 	// Aiven-engine fields.
 	Project     *string `json:"project,omitempty"`
 	ServiceName *string `json:"service_name,omitempty"`
@@ -808,12 +808,12 @@ type CreateBedrockAccessCredentialInput struct {
 }
 
 type UpdateBedrockAccessCredentialInput struct {
-	Name            *string `json:"name,omitempty"`
-	Description     *string `json:"description,omitempty"`
-	SecretStoreID   *string `json:"secret_store_id,omitempty"`
-	Region          *string `json:"region,omitempty"`
-	AccessKeyID     *string `json:"access_key_id,omitempty"`
-	SecretAccessKey *string `json:"secret_access_key,omitempty"`
+	Name            *string              `json:"name,omitempty"`
+	Description     *string              `json:"description,omitempty"`
+	SecretStoreID   *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Region          *string              `json:"region,omitempty"`
+	AccessKeyID     *string              `json:"access_key_id,omitempty"`
+	SecretAccessKey *string              `json:"secret_access_key,omitempty"`
 }
 
 func CreateBedrockAccessCredential(ctx context.Context, c *Client, input *CreateBedrockAccessCredentialInput) (*BedrockAccessCredential, error) {
@@ -877,10 +877,10 @@ type CreateApigeeAccessCredentialInput struct {
 }
 
 type UpdateApigeeAccessCredentialInput struct {
-	Name              *string `json:"name,omitempty"`
-	Description       *string `json:"description,omitempty"`
-	SecretStoreID     *string `json:"secret_store_id,omitempty"`
-	ServiceAccountKey *string `json:"service_account_key,omitempty"`
+	Name              *string              `json:"name,omitempty"`
+	Description       *string              `json:"description,omitempty"`
+	SecretStoreID     *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	ServiceAccountKey *string              `json:"service_account_key,omitempty"`
 }
 
 func CreateApigeeAccessCredential(ctx context.Context, c *Client, input *CreateApigeeAccessCredentialInput) (*ApigeeAccessCredential, error) {
@@ -953,15 +953,15 @@ type CreateElasticsearchAccessCredentialInput struct {
 }
 
 type UpdateElasticsearchAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	Host          *string `json:"host,omitempty"`
-	Port          *int    `json:"port,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
-	TLS           *bool   `json:"tls,omitempty"`
-	TLSCA         *string `json:"tls_ca,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Host          *string              `json:"host,omitempty"`
+	Port          *int                 `json:"port,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
+	TLS           *bool                `json:"tls,omitempty"`
+	TLSCA         *string              `json:"tls_ca,omitempty"`
 }
 
 func CreateElasticsearchAccessCredential(ctx context.Context, c *Client, input *CreateElasticsearchAccessCredentialInput) (*ElasticsearchAccessCredential, error) {
@@ -1040,18 +1040,18 @@ type CreateRabbitmqAccessCredentialInput struct {
 }
 
 type UpdateRabbitmqAccessCredentialInput struct {
-	Name           *string `json:"name,omitempty"`
-	Description    *string `json:"description,omitempty"`
-	SecretStoreID  *string `json:"secret_store_id,omitempty"`
-	Host           *string `json:"host,omitempty"`
-	Port           *int    `json:"port,omitempty"`
-	ManagementPort *int    `json:"management_port,omitempty"`
-	Username       *string `json:"username,omitempty"`
-	Password       *string `json:"password,omitempty"`
-	Vhost          *string `json:"vhost,omitempty"`
-	TLS            *bool   `json:"tls,omitempty"`
-	TLSCA          *string `json:"tls_ca,omitempty"`
-	AutoRotateRoot *bool   `json:"auto_rotate_root,omitempty"`
+	Name           *string              `json:"name,omitempty"`
+	Description    *string              `json:"description,omitempty"`
+	SecretStoreID  *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Host           *string              `json:"host,omitempty"`
+	Port           *int                 `json:"port,omitempty"`
+	ManagementPort *int                 `json:"management_port,omitempty"`
+	Username       *string              `json:"username,omitempty"`
+	Password       *string              `json:"password,omitempty"`
+	Vhost          *string              `json:"vhost,omitempty"`
+	TLS            *bool                `json:"tls,omitempty"`
+	TLSCA          *string              `json:"tls_ca,omitempty"`
+	AutoRotateRoot *bool                `json:"auto_rotate_root,omitempty"`
 }
 
 func CreateRabbitmqAccessCredential(ctx context.Context, c *Client, input *CreateRabbitmqAccessCredentialInput) (*RabbitmqAccessCredential, error) {
@@ -1114,10 +1114,10 @@ type CreateGCPSAAccessCredentialInput struct {
 }
 
 type UpdateGCPSAAccessCredentialInput struct {
-	Name              *string `json:"name,omitempty"`
-	Description       *string `json:"description,omitempty"`
-	SecretStoreID     *string `json:"secret_store_id,omitempty"`
-	ServiceAccountKey *string `json:"service_account_key,omitempty"`
+	Name              *string              `json:"name,omitempty"`
+	Description       *string              `json:"description,omitempty"`
+	SecretStoreID     *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	ServiceAccountKey *string              `json:"service_account_key,omitempty"`
 }
 
 func CreateGCPSAAccessCredential(ctx context.Context, c *Client, input *CreateGCPSAAccessCredentialInput) (*GCPSAAccessCredential, error) {
@@ -1184,12 +1184,12 @@ type CreateAzureAppAccessCredentialInput struct {
 }
 
 type UpdateAzureAppAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	TenantID      *string `json:"tenant_id,omitempty"`
-	ClientID      *string `json:"client_id,omitempty"`
-	ClientSecret  *string `json:"client_secret,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	TenantID      *string              `json:"tenant_id,omitempty"`
+	ClientID      *string              `json:"client_id,omitempty"`
+	ClientSecret  *string              `json:"client_secret,omitempty"`
 }
 
 func CreateAzureAppAccessCredential(ctx context.Context, c *Client, input *CreateAzureAppAccessCredentialInput) (*AzureAppAccessCredential, error) {
@@ -1256,12 +1256,12 @@ type CreateAWSAccessKeyAccessCredentialInput struct {
 }
 
 type UpdateAWSAccessKeyAccessCredentialInput struct {
-	Name               *string `json:"name,omitempty"`
-	Description        *string `json:"description,omitempty"`
-	SecretStoreID      *string `json:"secret_store_id,omitempty"`
-	AccessKeyID        *string `json:"access_key_id,omitempty"`
-	SecretAccessKey    *string `json:"secret_access_key,omitempty"`
-	PermissionBoundary *bool   `json:"permission_boundary,omitempty"`
+	Name               *string              `json:"name,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	SecretStoreID      *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	AccessKeyID        *string              `json:"access_key_id,omitempty"`
+	SecretAccessKey    *string              `json:"secret_access_key,omitempty"`
+	PermissionBoundary *bool                `json:"permission_boundary,omitempty"`
 }
 
 func CreateAWSAccessKeyAccessCredential(ctx context.Context, c *Client, input *CreateAWSAccessKeyAccessCredentialInput) (*AWSAccessKeyAccessCredential, error) {
@@ -1328,12 +1328,12 @@ type CreateTwilioAccessCredentialInput struct {
 }
 
 type UpdateTwilioAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	AccountSID    *string `json:"account_sid,omitempty"`
-	APIKeySID     *string `json:"api_key_sid,omitempty"`
-	APIKeySecret  *string `json:"api_key_secret,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	AccountSID    *string              `json:"account_sid,omitempty"`
+	APIKeySID     *string              `json:"api_key_sid,omitempty"`
+	APIKeySecret  *string              `json:"api_key_secret,omitempty"`
 }
 
 func CreateTwilioAccessCredential(ctx context.Context, c *Client, input *CreateTwilioAccessCredentialInput) (*TwilioAccessCredential, error) {
@@ -1411,18 +1411,18 @@ type CreateSnowflakeAccessCredentialInput struct {
 }
 
 type UpdateSnowflakeAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	Account       *string `json:"account,omitempty"`
-	Warehouse     *string `json:"warehouse,omitempty"`
-	Database      *string `json:"database,omitempty"`
-	Schema        *string `json:"schema,omitempty"`
-	Role          *string `json:"role,omitempty"`
-	Username      *string `json:"username,omitempty"`
-	Password      *string `json:"password,omitempty"`
-	PrivateKey    *string `json:"private_key,omitempty"`
-	AuthMethod    *string `json:"auth_method,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Account       *string              `json:"account,omitempty"`
+	Warehouse     *string              `json:"warehouse,omitempty"`
+	Database      *string              `json:"database,omitempty"`
+	Schema        *string              `json:"schema,omitempty"`
+	Role          *string              `json:"role,omitempty"`
+	Username      *string              `json:"username,omitempty"`
+	Password      *string              `json:"password,omitempty"`
+	PrivateKey    *string              `json:"private_key,omitempty"`
+	AuthMethod    *string              `json:"auth_method,omitempty"`
 }
 
 func CreateSnowflakeAccessCredential(ctx context.Context, c *Client, input *CreateSnowflakeAccessCredentialInput) (*SnowflakeAccessCredential, error) {
@@ -1486,10 +1486,10 @@ type CreateAwsWifAccessCredentialInput struct {
 }
 
 type UpdateAwsWifAccessCredentialInput struct {
-	Name          *string  `json:"name,omitempty"`
-	Description   *string  `json:"description,omitempty"`
-	SecretStoreID *string  `json:"secret_store_id,omitempty"`
-	DeploymentIDs []string `json:"deployment_ids,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DeploymentIDs []string             `json:"deployment_ids,omitempty"`
 }
 
 func CreateAwsWifAccessCredential(ctx context.Context, c *Client, input *CreateAwsWifAccessCredentialInput) (*AwsWifAccessCredential, error) {
@@ -1558,13 +1558,13 @@ type CreateGitlabAccessCredentialInput struct {
 }
 
 type UpdateGitlabAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	Token         *string `json:"token,omitempty"`
-	BaseURL       *string `json:"base_url,omitempty"`
-	ResourceType  *string `json:"resource_type,omitempty"`
-	ResourceID    *string `json:"resource_id,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	Token         *string              `json:"token,omitempty"`
+	BaseURL       *string              `json:"base_url,omitempty"`
+	ResourceType  *string              `json:"resource_type,omitempty"`
+	ResourceID    *string              `json:"resource_id,omitempty"`
 }
 
 func CreateGitlabAccessCredential(ctx context.Context, c *Client, input *CreateGitlabAccessCredentialInput) (*GitlabAccessCredential, error) {
@@ -1635,14 +1635,14 @@ type CreateGcpWifAccessCredentialInput struct {
 }
 
 type UpdateGcpWifAccessCredentialInput struct {
-	Name               *string  `json:"name,omitempty"`
-	Description        *string  `json:"description,omitempty"`
-	SecretStoreID      *string  `json:"secret_store_id,omitempty"`
-	DeploymentIDs      []string `json:"deployment_ids,omitempty"`
-	ProjectNumber      *string  `json:"project_number,omitempty"`
-	PoolID             *string  `json:"pool_id,omitempty"`
-	WorkloadProviderID *string  `json:"workload_provider_id,omitempty"`
-	Audience           *string  `json:"audience,omitempty"`
+	Name               *string              `json:"name,omitempty"`
+	Description        *string              `json:"description,omitempty"`
+	SecretStoreID      *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DeploymentIDs      []string             `json:"deployment_ids,omitempty"`
+	ProjectNumber      *string              `json:"project_number,omitempty"`
+	PoolID             *string              `json:"pool_id,omitempty"`
+	WorkloadProviderID *string              `json:"workload_provider_id,omitempty"`
+	Audience           *string              `json:"audience,omitempty"`
 }
 
 func CreateGcpWifAccessCredential(ctx context.Context, c *Client, input *CreateGcpWifAccessCredentialInput) (*GcpWifAccessCredential, error) {
@@ -1706,10 +1706,10 @@ type CreateAzureWifAccessCredentialInput struct {
 }
 
 type UpdateAzureWifAccessCredentialInput struct {
-	Name          *string  `json:"name,omitempty"`
-	Description   *string  `json:"description,omitempty"`
-	SecretStoreID *string  `json:"secret_store_id,omitempty"`
-	DeploymentIDs []string `json:"deployment_ids,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	DeploymentIDs []string             `json:"deployment_ids,omitempty"`
 }
 
 func CreateAzureWifAccessCredential(ctx context.Context, c *Client, input *CreateAzureWifAccessCredentialInput) (*AzureWifAccessCredential, error) {
@@ -1775,12 +1775,12 @@ type CreateDatadogAccessCredentialInput struct {
 }
 
 type UpdateDatadogAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	APIKey        *string `json:"api_key,omitempty"`
-	AppKey        *string `json:"app_key,omitempty"`
-	Site          *string `json:"site,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	APIKey        *string              `json:"api_key,omitempty"`
+	AppKey        *string              `json:"app_key,omitempty"`
+	Site          *string              `json:"site,omitempty"`
 }
 
 func CreateDatadogAccessCredential(ctx context.Context, c *Client, input *CreateDatadogAccessCredentialInput) (*DatadogAccessCredential, error) {
@@ -1847,12 +1847,12 @@ type CreateSalesforceAccessCredentialInput struct {
 }
 
 type UpdateSalesforceAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	InstanceURL   *string `json:"instance_url,omitempty"`
-	ClientID      *string `json:"client_id,omitempty"`
-	ClientSecret  *string `json:"client_secret,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	InstanceURL   *string              `json:"instance_url,omitempty"`
+	ClientID      *string              `json:"client_id,omitempty"`
+	ClientSecret  *string              `json:"client_secret,omitempty"`
 }
 
 func CreateSalesforceAccessCredential(ctx context.Context, c *Client, input *CreateSalesforceAccessCredentialInput) (*SalesforceAccessCredential, error) {
@@ -1915,10 +1915,10 @@ type CreateSendGridAccessCredentialInput struct {
 }
 
 type UpdateSendGridAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	APIKey        *string `json:"api_key,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	APIKey        *string              `json:"api_key,omitempty"`
 }
 
 func CreateSendGridAccessCredential(ctx context.Context, c *Client, input *CreateSendGridAccessCredentialInput) (*SendGridAccessCredential, error) {
@@ -1981,10 +1981,10 @@ type CreateTemporalCloudAccessCredentialInput struct {
 }
 
 type UpdateTemporalCloudAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
-	APIKey        *string `json:"api_key,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
+	APIKey        *string              `json:"api_key,omitempty"`
 }
 
 func CreateTemporalCloudAccessCredential(ctx context.Context, c *Client, input *CreateTemporalCloudAccessCredentialInput) (*TemporalCloudAccessCredential, error) {
@@ -2070,9 +2070,9 @@ type CreateKafkaAccessCredentialInput struct {
 // UpdateKafkaAccessCredentialInput omits engine: it is immutable and ignored by
 // the API on update.
 type UpdateKafkaAccessCredentialInput struct {
-	Name          *string `json:"name,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	SecretStoreID *string `json:"secret_store_id,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	SecretStoreID *secretStoreIDUpdate `json:"secret_store_id,omitempty"`
 	// Native-engine fields.
 	BootstrapServers *string `json:"bootstrap_servers,omitempty"`
 	Username         *string `json:"username,omitempty"`

--- a/internal/provider/acc_tests/secret_store_id_clear_test.go
+++ b/internal/provider/acc_tests/secret_store_id_clear_test.go
@@ -1,0 +1,75 @@
+package acc_tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hushsecurity/terraform-provider-hush/internal/testutil"
+)
+
+// Mirror midgard: secret_store_id must be a valid sst- id or explicit null.
+// The empty string reaches the mock only if the provider clears the field with
+// "" instead of null, so rejecting it here makes every credential update test
+// guard the three-state PATCH contract. Registered on the computed-fields key so
+// it fires for every access-credential subtype.
+func init() {
+	registerMockSetup(func(ms *testutil.MockServer) {
+		ms.OnOperation("access_credential", testutil.OpUpdate, func(op testutil.Operation, obj map[string]any) *testutil.HookError {
+			if v, ok := obj["secret_store_id"]; ok {
+				if s, isStr := v.(string); isStr && s == "" {
+					return &testutil.HookError{
+						Status: 400,
+						Detail: "secret_store_id must be a valid sst- id or null",
+					}
+				}
+			}
+			return nil
+		})
+	})
+}
+
+// TestAccResourcePlaintextAccessCredentialSecretStoreIDClear verifies that
+// detaching a credential from its secret store is an in-place update that sends
+// null (not ""), so the credential keeps its id and the field is cleared.
+func TestAccResourcePlaintextAccessCredentialSecretStoreIDClear(t *testing.T) {
+	var id string
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      validateResourceDestroyed("plaintext_access_credential", "v1/access_credentials"),
+		Steps: []resource.TestStep{
+			{
+				Config: plaintextSecretStoreClearStep1,
+				Check: resource.ComposeTestCheckFunc(
+					checkSecretStoreID("hush_plaintext_access_credential.clear"),
+					recordID("hush_plaintext_access_credential.clear", &id),
+				),
+			},
+			{
+				Config: plaintextSecretStoreClearStep2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"hush_plaintext_access_credential.clear", "secret_store_id", "",
+					),
+					checkIDUnchanged("hush_plaintext_access_credential.clear", &id),
+				),
+			},
+		},
+	})
+}
+
+const plaintextSecretStoreClearStep1 = `
+resource "hush_plaintext_access_credential" "clear" {
+  name            = "test-plaintext-clear"
+  deployment_ids  = ["` + mockDeploymentID + `"]
+  secret_store_id = "sst-mock-store-1"
+  secret          = "s3cr3t-value"
+}
+`
+
+const plaintextSecretStoreClearStep2 = `
+resource "hush_plaintext_access_credential" "clear" {
+  name           = "test-plaintext-clear"
+  deployment_ids = ["` + mockDeploymentID + `"]
+  secret         = "s3cr3t-value"
+}
+`

--- a/internal/provider/apigee_access_credential/resource.go
+++ b/internal/provider/apigee_access_credential/resource.go
@@ -122,7 +122,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("service_account_key") || d.HasChange("service_account_key_wo") || d.HasChange("service_account_key_wo_version") {
 		input.ServiceAccountKey = getServiceAccountKey(d)

--- a/internal/provider/aws_access_key_access_credential/resource.go
+++ b/internal/provider/aws_access_key_access_credential/resource.go
@@ -132,7 +132,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("access_key_id_value") {
 		v := d.Get("access_key_id_value").(string)

--- a/internal/provider/aws_wif_access_credential/resource.go
+++ b/internal/provider/aws_wif_access_credential/resource.go
@@ -111,7 +111,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("deployment_ids") {
 		deploymentIDs := make([]string, 0)

--- a/internal/provider/azure_app_access_credential/resource.go
+++ b/internal/provider/azure_app_access_credential/resource.go
@@ -132,7 +132,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("tenant_id") {
 		v := d.Get("tenant_id").(string)

--- a/internal/provider/azure_wif_access_credential/resource.go
+++ b/internal/provider/azure_wif_access_credential/resource.go
@@ -111,7 +111,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("deployment_ids") {
 		deploymentIDs := make([]string, 0)

--- a/internal/provider/bedrock_access_credential/resource.go
+++ b/internal/provider/bedrock_access_credential/resource.go
@@ -144,7 +144,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("region") {
 		v := d.Get("region").(string)

--- a/internal/provider/datadog_access_credential/resource.go
+++ b/internal/provider/datadog_access_credential/resource.go
@@ -127,7 +127,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("site") {
 		v := d.Get("site").(string)

--- a/internal/provider/elasticsearch_access_credential/resource.go
+++ b/internal/provider/elasticsearch_access_credential/resource.go
@@ -128,7 +128,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("host") {
 		v := d.Get("host").(string)

--- a/internal/provider/gcp_sa_access_credential/resource.go
+++ b/internal/provider/gcp_sa_access_credential/resource.go
@@ -118,7 +118,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("service_account_key") || d.HasChange("service_account_key_wo") || d.HasChange("service_account_key_wo_version") {
 		serviceAccountKey := getServiceAccountKey(d)

--- a/internal/provider/gcp_wif_access_credential/resource.go
+++ b/internal/provider/gcp_wif_access_credential/resource.go
@@ -121,7 +121,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("deployment_ids") {
 		deploymentIDs := make([]string, 0)

--- a/internal/provider/gemini_access_credential/resource.go
+++ b/internal/provider/gemini_access_credential/resource.go
@@ -120,7 +120,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("project_id") {
 		v := d.Get("project_id").(string)

--- a/internal/provider/gitlab_access_credential/resource.go
+++ b/internal/provider/gitlab_access_credential/resource.go
@@ -123,7 +123,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("token") || d.HasChange("token_wo") || d.HasChange("token_wo_version") {
 		v := getToken(d)

--- a/internal/provider/grok_access_credential/resource.go
+++ b/internal/provider/grok_access_credential/resource.go
@@ -117,7 +117,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("team_id") {
 		v := d.Get("team_id").(string)

--- a/internal/provider/kafka_access_credential/resource.go
+++ b/internal/provider/kafka_access_credential/resource.go
@@ -224,7 +224,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("bootstrap_servers") {
 		v := d.Get("bootstrap_servers").(string)

--- a/internal/provider/kv_access_credential/resource.go
+++ b/internal/provider/kv_access_credential/resource.go
@@ -132,7 +132,7 @@ func kvAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if d.HasChange("secret_store_id") {
 		secretStoreID := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &secretStoreID
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(secretStoreID)
 	}
 
 	if d.HasChange("items") {

--- a/internal/provider/mariadb_access_credential/resource.go
+++ b/internal/provider/mariadb_access_credential/resource.go
@@ -130,7 +130,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("db_name") {
 		v := d.Get("db_name").(string)

--- a/internal/provider/mongodb_access_credential/resource.go
+++ b/internal/provider/mongodb_access_credential/resource.go
@@ -132,7 +132,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("db_name") {
 		v := d.Get("db_name").(string)

--- a/internal/provider/mongodb_atlas_access_credential/resource.go
+++ b/internal/provider/mongodb_atlas_access_credential/resource.go
@@ -152,7 +152,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("group_id") {
 		v := d.Get("group_id").(string)

--- a/internal/provider/mysql_access_credential/resource.go
+++ b/internal/provider/mysql_access_credential/resource.go
@@ -130,7 +130,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("db_name") {
 		v := d.Get("db_name").(string)

--- a/internal/provider/openai_access_credential/resource.go
+++ b/internal/provider/openai_access_credential/resource.go
@@ -120,7 +120,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("project_id") {
 		v := d.Get("project_id").(string)

--- a/internal/provider/plaintext_access_credential/resource.go
+++ b/internal/provider/plaintext_access_credential/resource.go
@@ -119,7 +119,7 @@ func plaintextAccessCredentialUpdate(ctx context.Context, d *schema.ResourceData
 
 	if d.HasChange("secret_store_id") {
 		secretStoreID := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &secretStoreID
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(secretStoreID)
 	}
 
 	if d.HasChange("secret") || d.HasChange("secret_wo") || d.HasChange("secret_wo_version") {

--- a/internal/provider/postgres_access_credential/resource.go
+++ b/internal/provider/postgres_access_credential/resource.go
@@ -130,7 +130,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("db_name") {
 		v := d.Get("db_name").(string)

--- a/internal/provider/rabbitmq_access_credential/resource.go
+++ b/internal/provider/rabbitmq_access_credential/resource.go
@@ -136,7 +136,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("host") {
 		v := d.Get("host").(string)

--- a/internal/provider/redis_access_credential/resource.go
+++ b/internal/provider/redis_access_credential/resource.go
@@ -262,7 +262,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("host") {
 		v := d.Get("host").(string)

--- a/internal/provider/salesforce_access_credential/resource.go
+++ b/internal/provider/salesforce_access_credential/resource.go
@@ -121,7 +121,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("instance_url") {
 		v := d.Get("instance_url").(string)

--- a/internal/provider/sendgrid_access_credential/resource.go
+++ b/internal/provider/sendgrid_access_credential/resource.go
@@ -117,7 +117,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("api_key") || d.HasChange("api_key_wo") || d.HasChange("api_key_wo_version") {
 		v := getAPIKey(d)

--- a/internal/provider/snowflake_access_credential/resource.go
+++ b/internal/provider/snowflake_access_credential/resource.go
@@ -132,7 +132,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("account") {
 		v := d.Get("account").(string)

--- a/internal/provider/temporal_cloud_access_credential/resource.go
+++ b/internal/provider/temporal_cloud_access_credential/resource.go
@@ -115,7 +115,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("api_key") || d.HasChange("api_key_wo") || d.HasChange("api_key_wo_version") {
 		apiKey := writeonly.GetString(d, "api_key", "api_key_wo")

--- a/internal/provider/twilio_access_credential/resource.go
+++ b/internal/provider/twilio_access_credential/resource.go
@@ -121,7 +121,7 @@ func resourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.
 	}
 	if d.HasChange("secret_store_id") {
 		v := d.Get("secret_store_id").(string)
-		input.SecretStoreID = &v
+		input.SecretStoreID = client.NewSecretStoreIDUpdate(v)
 	}
 	if d.HasChange("account_sid") {
 		v := d.Get("account_sid").(string)


### PR DESCRIPTION
Removing secret_store_id from a credential that had one failed at apply.
The provider set the field on update via a *string with omitempty; a non-nil
pointer to "" marshals as "secret_store_id":"", not null. Midgard types the
field as Optional[SecretStoreID] on every credential PATCH model, so "" fails
id validation (422), and clears only on explicit null (handlers dump with
exclude_unset=True, and validate_secret_store_change returns early on None).

Introduce a secretStoreIDUpdate wrapper, mirroring oidcProviderUpdate, that
marshals to null when the id is empty and to the id otherwise, kept behind
omitempty so an unchanged field is still omitted. Route every credential update
through NewSecretStoreIDUpdate.

Marshaling an empty id as null unconditionally is safe because a user can never
set secret_store_id to "": the schema's ^sst- ValidateFunc rejects an explicit
secret_store_id = "" at plan (the SDK runs ValidateFunc on an explicitly-set
empty string, not only on omitted ones). An empty value can therefore arise only
from removing the attribute -- the clear case -- so the wrapper never turns a
real user-set value into null.

Add a client marshal test for the three states and an acceptance test that
detaches a store in place; the mock now rejects an empty secret_store_id so the
whole credential update suite enforces the null-or-valid-id contract.
