### PR TITLE
HUSH-6698 Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -376,3 +376,33 @@ resource "hush_deployment" "k8s" {
 * **Modular Architecture**: Organize provider code into modular structure following Terraform best practices
 * **Enhanced HTTP Client**: Proper error handling, token lifecycle management, and response body closure
 * **Go 1.24 Support**: Built with latest Go toolchain for optimal performance and security
+
+[1.20.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.19.0...v1.20.0
+[1.19.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.18.0...v1.19.0
+[1.18.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.17.0...v1.18.0
+[1.17.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.16.1...v1.17.0
+[1.16.1]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.16.0...v1.16.1
+[1.16.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.15.0...v1.16.0
+[1.15.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.14.0...v1.15.0
+[1.14.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.13.0...v1.14.0
+[1.13.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.12.0...v1.13.0
+[1.12.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.11.0...v1.12.0
+[1.11.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.10.0...v1.11.0
+[1.10.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.9.0...v1.10.0
+[1.9.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.8.0...v1.9.0
+[1.8.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.5.0...v1.6.0
+[1.5.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.3.4...v1.4.0
+[1.3.4]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.3.3...v1.3.4
+[1.3.3]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.3.2...v1.3.3
+[1.3.2]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/hushsecurity/terraform-provider-hush/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.20.1] - 2026-07-21
+
+### Fixed
+
+* **Plaintext and KV access credentials**: rotating the secret is now an in-place update instead of a destroy-and-recreate. Changing `secret` (or `secret_wo`/`secret_wo_version`) on `hush_plaintext_access_credential`, or `items` on `hush_kv_access_credential`, no longer forces replacement, so the credential keeps its id.
+* **Data-source lookups by name**: the `hush_*_integration`, `hush_deployment`, `hush_notification_channel`, and `hush_notification_configuration` data sources now read all pages when resolving by `name` (or `trigger`), returning the complete set of matches instead of only the first page.
+
 ## [1.20.0] - 2026-07-19
 
 ### Added
@@ -377,6 +384,7 @@ resource "hush_deployment" "k8s" {
 * **Enhanced HTTP Client**: Proper error handling, token lifecycle management, and response body closure
 * **Go 1.24 Support**: Built with latest Go toolchain for optimal performance and security
 
+[1.20.1]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.18.0...v1.19.0
 [1.18.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.17.0...v1.18.0


### PR DESCRIPTION
- **HUSH-6698 changelog: link version headers to GitHub diffs**
- **HUSH-6698 changelog: release 1.20.1**
