### PR TITLE
HUSH-6853 deployment: trust several OIDC issuers per deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 
 ---
 
+## [1.22.0] - 2026-08-07
+
+### Added
+
+* **Multiple deployment OIDC providers**: `oidc_provider` on `hush_deployment` may now be repeated, up to eight times, so a deployment can trust more than one issuer. Each issuer may appear once.
+
+  Existing configurations need no change. Note that the blocks are stored in the API's `oidc_providers` field: the provider writes that field and clears the singular `oidc_provider` in the same request. A deployment created by this release is stored that way from the start; one that predates it moves the first time its blocks change. Both fields are read, so a deployment written before this release still reads back correctly.
+
+  **Downgrading is one way.** Once a deployment is stored in `oidc_providers`, provider 1.21.0 and earlier read no issuers from it, show a permanent diff proposing to add `oidc_provider`, and fail with `422 set oidc_provider or oidc_providers, not both` on apply. Pin or roll forward together -- a teammate or a CI job left on the older provider cannot manage such a deployment.
+
+```hcl
+resource "hush_deployment" "multi_oidc" {
+  name     = "multi-oidc-deployment"
+  env_type = "dev"
+  kind     = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/AAAA1111BBBB2222CCCC3333DDDD4444"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/EEEE5555FFFF6666AAAA7777BBBB8888"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+}
+```
+
 ## [1.21.0] - 2026-08-04
 
 ### Added
@@ -412,6 +442,7 @@ resource "hush_deployment" "k8s" {
 * **Enhanced HTTP Client**: Proper error handling, token lifecycle management, and response body closure
 * **Go 1.24 Support**: Built with latest Go toolchain for optimal performance and security
 
+[1.22.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.21.0...v1.22.0
 [1.21.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.20.1...v1.21.0
 [1.20.1]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.20.0...v1.20.1
 [1.20.0]: https://github.com/hushsecurity/terraform-provider-hush/compare/v1.19.0...v1.20.0

--- a/docs/data-sources/deployment.md
+++ b/docs/data-sources/deployment.md
@@ -49,7 +49,7 @@ output "status" {
 - `description` (String) The description of the deployment
 - `env_type` (String) The environment type for the deployment (dev, prod)
 - `kind` (String) The deployment kind (k8s, ecs, serverless)
-- `oidc_provider` (List of Object) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. (see [below for nested schema](#nestedatt--oidc_provider))
+- `oidc_provider` (List of Object) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. Repeat the block to trust more than one issuer. Every block is stored in the API's 'oidc_providers' field, and each issuer may appear once. (see [below for nested schema](#nestedatt--oidc_provider))
 - `status` (String) The current status of the deployment
 
 <a id="nestedatt--oidc_provider"></a>

--- a/docs/resources/deployment.md
+++ b/docs/resources/deployment.md
@@ -35,6 +35,26 @@ resource "hush_deployment" "oidc" {
   }
 }
 
+# A deployment that trusts more than one issuer. Repeat the block per issuer --
+# the provider stores them all in the API's oidc_providers field.
+resource "hush_deployment" "multi_oidc" {
+  name     = "multi-oidc-deployment"
+  env_type = "dev"
+  kind     = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/AAAA1111BBBB2222CCCC3333DDDD4444"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/EEEE5555FFFF6666AAAA7777BBBB8888"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+}
+
 output "deployment" {
   value = hush_deployment.example
 }
@@ -52,7 +72,7 @@ output "deployment" {
 
 - `description` (String) The description of the deployment
 - `env_type` (String) The environment type for the deployment (dev, prod)
-- `oidc_provider` (Block List, Max: 1) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. (see [below for nested schema](#nestedblock--oidc_provider))
+- `oidc_provider` (Block List, Max: 8) Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. Repeat the block to trust more than one issuer. Every block is stored in the API's 'oidc_providers' field, and each issuer may appear once. (see [below for nested schema](#nestedblock--oidc_provider))
 
 ### Read-Only
 

--- a/examples/resources/hush_deployment/resource.tf
+++ b/examples/resources/hush_deployment/resource.tf
@@ -20,6 +20,26 @@ resource "hush_deployment" "oidc" {
   }
 }
 
+# A deployment that trusts more than one issuer. Repeat the block per issuer --
+# the provider stores them all in the API's oidc_providers field.
+resource "hush_deployment" "multi_oidc" {
+  name     = "multi-oidc-deployment"
+  env_type = "dev"
+  kind     = "k8s"
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/AAAA1111BBBB2222CCCC3333DDDD4444"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+
+  oidc_provider {
+    issuer           = "https://oidc.eks.eu-central-1.amazonaws.com/id/EEEE5555FFFF6666AAAA7777BBBB8888"
+    audience         = "https://kubernetes.default.svc"
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+}
+
 output "deployment" {
   value = hush_deployment.example
 }

--- a/internal/client/deployment.go
+++ b/internal/client/deployment.go
@@ -18,35 +18,42 @@ type OidcConfig struct {
 }
 
 type Deployment struct {
-	ID           string      `json:"id,omitempty"`
-	Name         string      `json:"name"`
-	Description  string      `json:"description,omitempty"`
-	EnvType      string      `json:"env_type"`
-	Status       string      `json:"status,omitempty"`
-	Kind         string      `json:"kind,omitempty"`
-	OidcProvider *OidcConfig `json:"oidc_provider,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	EnvType     string `json:"env_type"`
+	Status      string `json:"status,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	// The API holds one field or the other, never both, and refuses a change
+	// that would leave it holding the pair. Both are read: a deployment this
+	// provider has not written since the list was introduced still answers
+	// through the singular field.
+	OidcProvider  *OidcConfig  `json:"oidc_provider,omitempty"`
+	OidcProviders []OidcConfig `json:"oidc_providers,omitempty"`
 }
 
 // CreateDeploymentInput represents the input for creating a deployment
 type CreateDeploymentInput struct {
-	Name         string      `json:"name"`
-	Description  string      `json:"description,omitempty"`
-	EnvType      string      `json:"env_type"`
-	Kind         string      `json:"kind,omitempty"`
-	OidcProvider *OidcConfig `json:"oidc_provider,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	EnvType     string `json:"env_type"`
+	Kind        string `json:"kind,omitempty"`
+	// Only the list is ever written. The singular field is left out, which a
+	// create reads as absent, so the two are never sent together.
+	OidcProviders []OidcConfig `json:"oidc_providers,omitempty"`
 }
 
 // UpdateDeploymentInput represents the input for updating a deployment. Each
-// scalar is a pointer with omitempty so only changed fields are sent. The
-// oidc_provider field needs three states -- omitted (unchanged), set, and
-// explicit null (removed) -- which omitempty alone cannot express, so it uses
-// the oidcProviderUpdate wrapper.
+// scalar is a pointer with omitempty so only changed fields are sent. The OIDC
+// fields need three states -- omitted (unchanged), set, and explicit null
+// (removed) -- which omitempty alone cannot express, so each uses a wrapper.
 type UpdateDeploymentInput struct {
-	Name         *string             `json:"name,omitempty"`
-	Description  *string             `json:"description,omitempty"`
-	EnvType      *string             `json:"env_type,omitempty"`
-	Kind         *string             `json:"kind,omitempty"`
-	OidcProvider *oidcProviderUpdate `json:"oidc_provider,omitempty"`
+	Name          *string              `json:"name,omitempty"`
+	Description   *string              `json:"description,omitempty"`
+	EnvType       *string              `json:"env_type,omitempty"`
+	Kind          *string              `json:"kind,omitempty"`
+	OidcProvider  *oidcProviderUpdate  `json:"oidc_provider,omitempty"`
+	OidcProviders *oidcProvidersUpdate `json:"oidc_providers,omitempty"`
 }
 
 // oidcProviderUpdate marshals to null when Config is nil (removal) and to the
@@ -64,6 +71,23 @@ func (o oidcProviderUpdate) MarshalJSON() ([]byte, error) {
 // update request, forcing the oidc_provider field to be sent.
 func NewOidcProviderUpdate(config *OidcConfig) *oidcProviderUpdate {
 	return &oidcProviderUpdate{Config: config}
+}
+
+// oidcProvidersUpdate is the list counterpart of oidcProviderUpdate. The API
+// rejects an empty list, so removal is an explicit null rather than [].
+type oidcProvidersUpdate struct{ Configs []OidcConfig }
+
+func (o oidcProvidersUpdate) MarshalJSON() ([]byte, error) {
+	if len(o.Configs) == 0 {
+		return []byte("null"), nil
+	}
+	return json.Marshal(o.Configs)
+}
+
+// NewOidcProvidersUpdate wraps a list of OIDC configs (empty for removal) for
+// an update request, forcing the oidc_providers field to be sent.
+func NewOidcProvidersUpdate(configs []OidcConfig) *oidcProvidersUpdate {
+	return &oidcProvidersUpdate{Configs: configs}
 }
 
 // DeploymentCredentialsResponse embeds Deployment and adds credentials

--- a/internal/client/deployment_test.go
+++ b/internal/client/deployment_test.go
@@ -56,3 +56,108 @@ func TestUpdateDeploymentInput_OidcProviderMarshaling(t *testing.T) {
 		})
 	}
 }
+
+// TestUpdateDeploymentInput_OidcProvidersMarshaling verifies the three update
+// states of oidc_providers. Removal is an explicit null rather than an empty
+// list, because the API rejects [].
+func TestUpdateDeploymentInput_OidcProvidersMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    UpdateDeploymentInput
+		contains string
+		omits    bool
+	}{
+		{
+			name:  "unchanged omits the field",
+			input: UpdateDeploymentInput{},
+			omits: true,
+		},
+		{
+			name:     "removal sends explicit null",
+			input:    UpdateDeploymentInput{OidcProviders: NewOidcProvidersUpdate(nil)},
+			contains: `"oidc_providers":null`,
+		},
+		{
+			name:     "an empty list is a removal, not an empty array",
+			input:    UpdateDeploymentInput{OidcProviders: NewOidcProvidersUpdate([]OidcConfig{})},
+			contains: `"oidc_providers":null`,
+		},
+		{
+			name: "set sends every entry in order",
+			input: UpdateDeploymentInput{OidcProviders: NewOidcProvidersUpdate([]OidcConfig{
+				{
+					Issuer:          "https://blue.example.com",
+					Audience:        "hush",
+					AllowedSubjects: []string{"system:serviceaccount:hush-security:*"},
+				},
+				{
+					Issuer:   "https://green.example.com",
+					Audience: "hush",
+				},
+			})},
+			contains: `"oidc_providers":[{"issuer":"https://blue.example.com","audience":"hush","allowed_subjects":["system:serviceaccount:hush-security:*"]},{"issuer":"https://green.example.com","audience":"hush"}]`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal failed: %v", err)
+			}
+			got := string(b)
+			if tc.omits {
+				if strings.Contains(got, "oidc_providers") {
+					t.Fatalf("expected oidc_providers to be omitted, got %s", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.contains) {
+				t.Fatalf("expected %s to contain %s", got, tc.contains)
+			}
+		})
+	}
+}
+
+// The API refuses a change that would leave a deployment holding both fields,
+// so an update that writes the list has to clear the singular one in the same
+// request: one value and one explicit null, never two values.
+func TestUpdateDeploymentInput_WritesListAndClearsSingular(t *testing.T) {
+	input := UpdateDeploymentInput{
+		OidcProviders: NewOidcProvidersUpdate([]OidcConfig{
+			{Issuer: "https://blue.example.com", Audience: "hush"},
+		}),
+		OidcProvider: NewOidcProviderUpdate(nil),
+	}
+	b, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, `"oidc_provider":null`) {
+		t.Fatalf("expected the singular field cleared in %s", got)
+	}
+	if !strings.Contains(got, `"oidc_providers":[{"issuer":"https://blue.example.com"`) {
+		t.Fatalf("expected the list written in %s", got)
+	}
+}
+
+// A create never sends the singular field at all, so the pair cannot reach the
+// API from that path either.
+func TestCreateDeploymentInput_SendsOnlyTheList(t *testing.T) {
+	b, err := json.Marshal(CreateDeploymentInput{
+		Name:          "d",
+		Kind:          "k8s",
+		OidcProviders: []OidcConfig{{Issuer: "https://a.example.com", Audience: "hush"}},
+	})
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	got := string(b)
+	if strings.Contains(got, `"oidc_provider"`) {
+		t.Fatalf("expected no oidc_provider in %s", got)
+	}
+	if !strings.Contains(got, `"oidc_providers":[`) {
+		t.Fatalf("expected oidc_providers in %s", got)
+	}
+}

--- a/internal/provider/acc_tests/deployment_oidc_providers_test.go
+++ b/internal/provider/acc_tests/deployment_oidc_providers_test.go
@@ -1,0 +1,249 @@
+package acc_tests
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hushsecurity/terraform-provider-hush/internal/testutil"
+)
+
+// Mirror the API's rules on the OIDC fields, and pin the provider's own side of
+// the contract. The hook runs on the merged object, so it sees exactly the state
+// a request would leave behind, and it is registered from init() so it applies
+// to every deployment update in the package rather than only to this test.
+//
+// Without it the mock accepts anything and each of the three mistakes below
+// passes here while the real API refuses it.
+func init() {
+	registerMockSetup(func(ms *testutil.MockServer) {
+		ms.OnOperation("deployment", testutil.OpUpdate,
+			func(op testutil.Operation, obj map[string]any) *testutil.HookError {
+				// API rule: a change must not leave the deployment holding
+				// both fields. Fires when a write of the list fails to clear
+				// the singular field a deployment already holds.
+				if obj["oidc_provider"] != nil && obj["oidc_providers"] != nil {
+					return &testutil.HookError{
+						Status: 422,
+						Detail: "set oidc_provider or oidc_providers, not both",
+					}
+				}
+
+				// API rule: the list has a minimum length, so removal is an
+				// explicit null. Belt and braces -- removal takes the nil path
+				// and Go marshals a nil slice to null on its own, so this only
+				// fires for a non-nil empty slice. The property is covered by
+				// TestUpdateDeploymentInput_OidcProvidersMarshaling; this keeps
+				// the mock faithful to the API rather than to what the provider
+				// happens to reach today.
+				if entries, ok := obj["oidc_providers"].([]any); ok &&
+					len(entries) == 0 {
+					return &testutil.HookError{
+						Status: 422,
+						Detail: "oidc_providers must not be empty",
+					}
+				}
+
+				// Provider contract rather than an API rule: this provider
+				// writes the list and never the singular field. The API would
+				// accept a lone singular value, so nothing else would notice a
+				// regression to writing it.
+				if obj["oidc_provider"] != nil {
+					return &testutil.HookError{
+						Status: 422,
+						Detail: "provider must not write oidc_provider",
+					}
+				}
+
+				return nil
+			})
+	})
+}
+
+// legacyOIDCDeploymentName marks the deployment the create hook below rewrites.
+// Keyed on the name so the rewrite reaches one test and leaves every other
+// deployment in the package alone.
+const legacyOIDCDeploymentName = "tf-acc-legacy-oidc"
+
+// Manufacture a deployment that holds the API's singular field, which this
+// provider never writes and so could not otherwise appear in a test. It stands
+// in for one created before the list shipped, and it is the only state in which
+// failing to clear the singular field on update is observable at all.
+//
+// The hook runs before the object is stored and before the response is encoded,
+// so both the stored deployment and the read-back carry the singular field.
+func init() {
+	registerMockSetup(func(ms *testutil.MockServer) {
+		ms.OnOperation("deployment", testutil.OpCreate,
+			func(op testutil.Operation, obj map[string]any) *testutil.HookError {
+				if obj["name"] != legacyOIDCDeploymentName {
+					return nil
+				}
+				if entries, ok := obj["oidc_providers"].([]any); ok &&
+					len(entries) == 1 {
+					obj["oidc_provider"] = entries[0]
+					delete(obj, "oidc_providers")
+				}
+				return nil
+			})
+	})
+}
+
+// TestAccResourceDeploymentOIDCMigratesFromTheSingularField is the migration
+// this commit exists for: a deployment that already holds the singular field
+// gains a second issuer. The update has to write the list and clear the
+// singular in one request, because the API resolves an absent field from the
+// stored deployment and refuses a change that would leave both set.
+//
+// Deleting the clear from deploymentUpdate makes step 2 fail here with the
+// API's own "not both". No other test in the suite can see that.
+func TestAccResourceDeploymentOIDCMigratesFromTheSingularField(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      validateResourceDestroyed("deployment", "v1/deployments"),
+		Steps: []resource.TestStep{
+			{
+				// Created with one block; the hook moves it to the singular
+				// field, so the stored deployment looks pre-list.
+				Config: deploymentLegacyOIDCConfig(oidcIssuer),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.legacy",
+						"oidc_provider.#", "1"),
+					resource.TestCheckResourceAttr("hush_deployment.legacy",
+						"oidc_provider.0.issuer", oidcIssuer),
+				),
+			},
+			{
+				// The second cluster joins. This is the request that has to
+				// carry the list and a null singular together.
+				Config: deploymentLegacyOIDCConfig(oidcIssuer, oidcIssuer2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.legacy",
+						"oidc_provider.#", "2"),
+					resource.TestCheckResourceAttr("hush_deployment.legacy",
+						"oidc_provider.1.issuer", oidcIssuer2),
+				),
+			},
+		},
+	})
+}
+
+// TestAccResourceDeploymentMultipleOIDCProviders walks the block from one
+// issuer to two and back, then removes it.
+//
+// Every step differs only in the OIDC blocks, so a failure cannot be blamed on
+// anything else changing at the same time.
+func TestAccResourceDeploymentMultipleOIDCProviders(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      validateResourceDestroyed("deployment", "v1/deployments"),
+		Steps: []resource.TestStep{
+			{
+				Config: deploymentMultiOIDCConfig(oidcIssuer),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.#", "1"),
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.0.issuer", oidcIssuer),
+				),
+			},
+			{
+				// The second cluster joins.
+				Config: deploymentMultiOIDCConfig(oidcIssuer, oidcIssuer2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.#", "2"),
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.0.issuer", oidcIssuer),
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.1.issuer", oidcIssuer2),
+				),
+			},
+			{
+				// The old cluster is gone.
+				Config: deploymentMultiOIDCConfig(oidcIssuer2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.#", "1"),
+					resource.TestCheckResourceAttr("hush_deployment.test",
+						"oidc_provider.0.issuer", oidcIssuer2),
+				),
+			},
+			{
+				// The same issuer twice is refused at plan time, before any
+				// request: selection matches on the issuer and takes the first
+				// entry, so the second would be unreachable.
+				Config: deploymentMultiOIDCConfig(oidcIssuer, oidcIssuer),
+				ExpectError: regexp.MustCompile(
+					`issuer .* is configured more than once`),
+			},
+			{
+				// Removing every block clears both fields, which the API
+				// accepts as two explicit nulls.
+				Config: deploymentMultiOIDCConfig(),
+				Check: resource.TestCheckResourceAttr("hush_deployment.test",
+					"oidc_provider.#", "0"),
+			},
+		},
+	})
+}
+
+// TestAccDataSourceDeploymentMultipleOIDCProviders verifies the data source
+// surfaces every block.
+func TestAccDataSourceDeploymentMultipleOIDCProviders(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      validateResourceDestroyed("deployment", "v1/deployments"),
+		Steps: []resource.TestStep{
+			{
+				Config: deploymentMultiOIDCConfig(oidcIssuer, oidcIssuer2) +
+					deploymentDataSource,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.hush_deployment.test",
+						"oidc_provider.#", "2"),
+					resource.TestCheckResourceAttr("data.hush_deployment.test",
+						"oidc_provider.0.issuer", oidcIssuer),
+					resource.TestCheckResourceAttr("data.hush_deployment.test",
+						"oidc_provider.1.issuer", oidcIssuer2),
+				),
+			},
+		},
+	})
+}
+
+// deploymentMultiOIDCConfig renders one oidc_provider block per issuer, at a
+// fixed deployment name so no step changes anything but the blocks.
+func deploymentMultiOIDCConfig(issuers ...string) string {
+	return deploymentOIDCBlocksConfig("test", "tf-acc-multi-oidc", issuers...)
+}
+
+// deploymentLegacyOIDCConfig renders the same shape at the name the create hook
+// rewrites, so the deployment under test holds the API's singular field.
+func deploymentLegacyOIDCConfig(issuers ...string) string {
+	return deploymentOIDCBlocksConfig(
+		"legacy", legacyOIDCDeploymentName, issuers...)
+}
+
+func deploymentOIDCBlocksConfig(
+	label, name string, issuers ...string,
+) string {
+	blocks := ""
+	for _, issuer := range issuers {
+		blocks += fmt.Sprintf(`
+  oidc_provider {
+    issuer           = %q
+    audience         = %q
+    allowed_subjects = ["system:serviceaccount:hush-security:*"]
+  }
+`, issuer, oidcAudience)
+	}
+
+	return fmt.Sprintf(`
+resource "hush_deployment" %q {
+  name     = %q
+  env_type = "dev"
+  kind     = "k8s"
+%s}
+`, label, name, blocks)
+}

--- a/internal/provider/deployment/common.go
+++ b/internal/provider/deployment/common.go
@@ -22,11 +22,16 @@ const (
 	passwordDesc        = "The deployment password for authentication"
 	imagePullSecretDesc = "The image pull secret for accessing private container images"
 
-	oidcProviderDesc        = "Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password."
+	oidcProviderDesc        = "Optional OIDC provider configuration enabling passwordless deployment token exchange. When set, the deployment can exchange a signed OIDC token (for example a Kubernetes service account token) for a deployment token instead of using the password. Repeat the block to trust more than one issuer. Every block is stored in the API's 'oidc_providers' field, and each issuer may appear once."
 	oidcIssuerDesc          = "The OIDC issuer URL (must be HTTPS). Its OpenID configuration and JWKS are used to verify presented assertions."
 	oidcAudienceDesc        = "The audience claim expected in presented OIDC assertions."
 	oidcAllowedSubjectsDesc = "Optional list of allowed subject claims. A trailing '*' acts as a prefix wildcard (for example 'system:serviceaccount:hush-security:*'). When omitted, any subject is accepted."
 )
+
+// maxOidcProviders mirrors the API cap on the field these blocks are stored
+// in. Every entry is another key set able to mint tokens for the deployment,
+// so the ceiling is worth stating here rather than discovering on a round trip.
+const maxOidcProviders = 8
 
 func DeploymentResourceSchema() map[string]*schema.Schema {
 	s := DeploymentDataSourceSchema()
@@ -90,7 +95,9 @@ func DeploymentResourceSchema() map[string]*schema.Schema {
 		Description: oidcProviderDesc,
 		Type:        schema.TypeList,
 		Optional:    true,
-		MaxItems:    1,
+		// The API caps the list it is stored in. Rejecting here says so while
+		// the caller can still act on it, rather than after a round trip.
+		MaxItems: maxOidcProviders,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"issuer": {
@@ -258,22 +265,32 @@ func setDeploymentFields(d *schema.ResourceData, deployment *client.Deployment) 
 		}
 	}
 
-	if err := d.Set("oidc_provider", flattenOidcProvider(deployment.OidcProvider)); err != nil {
+	if err := d.Set("oidc_provider", flattenOidcProviders(deployment)); err != nil {
 		return diag.FromErr(fmt.Errorf("failed to set oidc_provider: %w", err))
 	}
 
 	return nil
 }
 
-// flattenOidcProvider converts the API OIDC config into the single-element list
-// the nested block schema expects, or an empty list when none is configured.
-func flattenOidcProvider(oidc *client.OidcConfig) []map[string]any {
-	if oidc == nil {
-		return []map[string]any{}
+// flattenOidcProviders converts whichever OIDC field the deployment holds into
+// the block list, or an empty list when it holds neither.
+//
+// The list is preferred and the singular field is the fallback, so a deployment
+// this provider has not written since the list was introduced reads back as one
+// block and produces no diff against a configuration that declares one.
+func flattenOidcProviders(deployment *client.Deployment) []map[string]any {
+	configs := deployment.OidcProviders
+	if len(configs) == 0 && deployment.OidcProvider != nil {
+		configs = []client.OidcConfig{*deployment.OidcProvider}
 	}
-	return []map[string]any{{
-		"issuer":           oidc.Issuer,
-		"audience":         oidc.Audience,
-		"allowed_subjects": oidc.AllowedSubjects,
-	}}
+
+	out := make([]map[string]any, 0, len(configs))
+	for _, oidc := range configs {
+		out = append(out, map[string]any{
+			"issuer":           oidc.Issuer,
+			"audience":         oidc.Audience,
+			"allowed_subjects": oidc.AllowedSubjects,
+		})
+	}
+	return out
 }

--- a/internal/provider/deployment/oidc_providers_test.go
+++ b/internal/provider/deployment/oidc_providers_test.go
@@ -1,0 +1,128 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hushsecurity/terraform-provider-hush/internal/client"
+)
+
+func resourceDataFor(t *testing.T, raw map[string]any) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, DeploymentResourceSchema(), raw)
+}
+
+// A deployment spanning two clusters is expressed as two blocks, so order and
+// per-entry fields have to survive expansion intact.
+func TestExpandOidcProviders(t *testing.T) {
+	d := resourceDataFor(t, map[string]any{
+		"oidc_provider": []any{
+			map[string]any{
+				"issuer":           "https://blue.example.com",
+				"audience":         "hush",
+				"allowed_subjects": []any{"system:serviceaccount:hush-security:*"},
+			},
+			map[string]any{
+				"issuer":   "https://green.example.com",
+				"audience": "hush",
+			},
+		},
+	})
+
+	got := expandOidcProviders(d)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(got))
+	}
+	if got[0].Issuer != "https://blue.example.com" {
+		t.Fatalf("unexpected first issuer %q", got[0].Issuer)
+	}
+	if got[1].Issuer != "https://green.example.com" {
+		t.Fatalf("unexpected second issuer %q", got[1].Issuer)
+	}
+	if len(got[0].AllowedSubjects) != 1 {
+		t.Fatalf("expected the first entry to keep its subjects, got %v",
+			got[0].AllowedSubjects)
+	}
+	if got[1].AllowedSubjects != nil {
+		t.Fatalf("expected no subjects on the second entry, got %v",
+			got[1].AllowedSubjects)
+	}
+}
+
+// No block must expand to nil rather than an empty list, so an update that did
+// not touch the field sends nothing and one that emptied it sends null.
+func TestExpandOidcProvidersAbsent(t *testing.T) {
+	d := resourceDataFor(t, map[string]any{})
+	if got := expandOidcProviders(d); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}
+
+// The list is preferred on read.
+func TestFlattenOidcProvidersFromList(t *testing.T) {
+	got := flattenOidcProviders(&client.Deployment{
+		OidcProviders: []client.OidcConfig{
+			{Issuer: "https://blue.example.com", Audience: "hush"},
+			{Issuer: "https://green.example.com", Audience: "hush"},
+		},
+	})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(got))
+	}
+	if got[0]["issuer"] != "https://blue.example.com" {
+		t.Fatalf("unexpected first issuer %v", got[0]["issuer"])
+	}
+}
+
+// A deployment this provider has not written since the list was introduced
+// still answers through the singular field, and has to read back as one block
+// so a configuration declaring one produces no diff.
+func TestFlattenOidcProvidersFallsBackToSingular(t *testing.T) {
+	got := flattenOidcProviders(&client.Deployment{
+		OidcProvider: &client.OidcConfig{
+			Issuer:          "https://legacy.example.com",
+			Audience:        "hush",
+			AllowedSubjects: []string{"system:serviceaccount:hush-security:*"},
+		},
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0]["issuer"] != "https://legacy.example.com" {
+		t.Fatalf("unexpected issuer %v", got[0]["issuer"])
+	}
+}
+
+// Neither field set must flatten to an empty list rather than to null, or a
+// deployment with no OIDC would show a permanent diff.
+func TestFlattenOidcProvidersEmpty(t *testing.T) {
+	got := flattenOidcProviders(&client.Deployment{})
+	if got == nil {
+		t.Fatal("expected an empty list, got nil")
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected no entries, got %d", len(got))
+	}
+}
+
+// The block is the only OIDC surface the provider offers, and it is capped at
+// what the API accepts for the field it is stored in.
+func TestOidcProviderBlockCap(t *testing.T) {
+	s := DeploymentResourceSchema()
+
+	block, ok := s["oidc_provider"]
+	if !ok {
+		t.Fatal("oidc_provider missing from the resource schema")
+	}
+	if block.MaxItems != maxOidcProviders {
+		t.Fatalf("expected the block capped at %d, got %d",
+			maxOidcProviders, block.MaxItems)
+	}
+	if _, exists := s["oidc_providers"]; exists {
+		t.Fatal("oidc_providers must not be a separate field")
+	}
+	if block.Deprecated != "" {
+		t.Fatalf("oidc_provider is the surviving field, not deprecated: %q",
+			block.Deprecated)
+	}
+}

--- a/internal/provider/deployment/resource.go
+++ b/internal/provider/deployment/resource.go
@@ -23,19 +23,53 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Schema: DeploymentResourceSchema(),
+		CustomizeDiff: deploymentCustomizeDiff,
+		Schema:        DeploymentResourceSchema(),
 	}
+}
+
+// deploymentCustomizeDiff refuses a duplicate issuer at plan time. The API
+// refuses one too, but selection matches on the issuer and takes the first
+// entry, so a second entry for one issuer is unreachable and the audience or
+// subjects it carried would be dropped without a word -- worth saying while the
+// caller can still change it.
+//
+// Literals only. An issuer taken from another resource is unknown at plan time
+// and ResourceDiff yields the zero value for it -- d.NewValueKnown reports the
+// same thing without relying on that -- so it is skipped rather than reported,
+// because refusing a configuration that is very likely fine is worse than
+// leaving it to the API. For those the API stays the only check.
+func deploymentCustomizeDiff(
+	ctx context.Context, d *schema.ResourceDiff, m any,
+) error {
+	seen := make(map[string]struct{})
+	for _, entry := range d.Get("oidc_provider").([]any) {
+		fields, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		issuer, _ := fields["issuer"].(string)
+		if issuer == "" {
+			continue
+		}
+		if _, dup := seen[issuer]; dup {
+			return fmt.Errorf(
+				"oidc_provider: issuer %q is configured more than once", issuer)
+		}
+		seen[issuer] = struct{}{}
+	}
+	return nil
 }
 
 func deploymentCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
 	c := m.(*client.Client)
 
 	input := &client.CreateDeploymentInput{
-		Name:         d.Get("name").(string),
-		Description:  d.Get("description").(string),
-		EnvType:      d.Get("env_type").(string),
-		Kind:         d.Get("kind").(string),
-		OidcProvider: expandOidcProvider(d),
+		Name:          d.Get("name").(string),
+		Description:   d.Get("description").(string),
+		EnvType:       d.Get("env_type").(string),
+		Kind:          d.Get("kind").(string),
+		OidcProviders: expandOidcProviders(d),
 	}
 
 	resp, err := client.CreateDeploymentWithCredentials(ctx, c, input)
@@ -90,8 +124,16 @@ func deploymentUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 		input.Kind = &kind
 		hasChanges = true
 	}
+	// Write the list and clear the singular field in the same request. The API
+	// resolves each field from the change or, when absent, from the stored
+	// deployment, and refuses a change that would leave it holding both -- so
+	// sending the list alone would be measured against a stored singular and
+	// refused. Clearing it here is also what migrates a deployment that still
+	// holds the singular, without ever passing through a state that trusts no
+	// issuer.
 	if d.HasChange("oidc_provider") {
-		input.OidcProvider = client.NewOidcProviderUpdate(expandOidcProvider(d))
+		input.OidcProviders = client.NewOidcProvidersUpdate(expandOidcProviders(d))
+		input.OidcProvider = client.NewOidcProviderUpdate(nil)
 		hasChanges = true
 	}
 
@@ -112,26 +154,33 @@ func deploymentUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.D
 	return nil
 }
 
-// expandOidcProvider reads the oidc_provider block from configuration,
-// returning nil when the block is absent.
-func expandOidcProvider(d *schema.ResourceData) *client.OidcConfig {
+// expandOidcProviders reads the oidc_provider blocks from configuration,
+// returning nil when none is present. One block per trusted issuer, all of
+// them stored in the API's oidc_providers field.
+func expandOidcProviders(d *schema.ResourceData) []client.OidcConfig {
 	raw := d.Get("oidc_provider").([]any)
-	if len(raw) == 0 || raw[0] == nil {
+	if len(raw) == 0 {
 		return nil
 	}
-	m := raw[0].(map[string]any)
-
-	cfg := &client.OidcConfig{
-		Issuer:   m["issuer"].(string),
-		Audience: m["audience"].(string),
-	}
-	if subs, ok := m["allowed_subjects"].([]any); ok && len(subs) > 0 {
-		cfg.AllowedSubjects = make([]string, len(subs))
-		for i, s := range subs {
-			cfg.AllowedSubjects[i] = s.(string)
+	out := make([]client.OidcConfig, 0, len(raw))
+	for _, entry := range raw {
+		if entry == nil {
+			continue
 		}
+		fields := entry.(map[string]any)
+		cfg := client.OidcConfig{
+			Issuer:   fields["issuer"].(string),
+			Audience: fields["audience"].(string),
+		}
+		if subs, ok := fields["allowed_subjects"].([]any); ok && len(subs) > 0 {
+			cfg.AllowedSubjects = make([]string, len(subs))
+			for i, s := range subs {
+				cfg.AllowedSubjects[i] = s.(string)
+			}
+		}
+		out = append(out, cfg)
 	}
-	return cfg
+	return out
 }
 
 func deploymentDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {


### PR DESCRIPTION
A deployment can need to trust more than one OIDC issuer at once. Several
clusters may hold one deployment identity, each with its own issuer, and only
the cluster whose issuer is configured can exchange a service account assertion
for a deployment token. The API grew a list field to trust more than one; the
provider could express a single issuer, so that was not reachable through
terraform at all.

common.go, oidc_provider: raise the cap on the existing block rather than
adding a second one. Repeating a singular block is how HCL expresses a list,
existing configurations need no change at all, and a caller has no pair of
fields to set inconsistently. The provider does still move a deployment from one
API field to the other, in deploymentUpdate -- what is gone is the configuration
surface for getting that wrong.

Choosing the API field by block count -- singular for one, list for two or more
-- was rejected. It would spare the single-issuer case any migration, but it
makes where a deployment is stored a function of how many blocks it has, moves
it back when a second issuer is removed, and keeps alive a field the API means
to retire. Writing the list always is the simpler rule to hold, and the mock in
the acceptance tests now pins it.

common.go, maxOidcProviders: the cap is the API's eight. Every entry is another
key set able to mint tokens for the deployment, so the ceiling is worth stating
before a round trip rather than after one.

resource.go, deploymentUpdate: write the list and clear the singular field in
one request. The API resolves each field from the change or, when it is absent,
from the stored deployment, and refuses a change that would leave the deployment
holding both -- so writing the list alone would be measured against the stored
singular and refused. Clearing it in the same request is also what migrates a
deployment that still holds the singular, without passing through a state that
trusts no issuer.

resource.go, deploymentUpdate: do this only when the block changed. Sending the
OIDC fields on every update would silently rewrite where a deployment's issuers
are stored because someone edited its description.

common.go, flattenOidcProviders: read both fields, preferring the list. A
deployment this provider has not written since the list was introduced still
answers through the singular field, and reads back as one block, so a
configuration declaring one produces no diff.

resource.go, deploymentCustomizeDiff: refuse a duplicate issuer at plan time.
The API refuses one too, but selection matches on the issuer and takes the first
entry, so a second entry for one issuer is unreachable and the audience or
subjects it carried would be dropped without a word. Literals only: an issuer
taken from another resource is unknown at plan time and is skipped rather than
reported, because refusing a configuration that is very likely fine is worse
than leaving it to the API.

client/deployment.go, oidcProvidersUpdate: marshal an empty list to null. The
field needs the same three update states the singular one has -- omitted, set,
removed -- and the API rejects [], so removal is the explicit null.

client/deployment.go, CreateDeploymentInput: carry only the list. A create that
never mentions the singular field cannot send the pair, so the rule above has
nothing to enforce on that path.

acc_tests/deployment_oidc_providers_test.go: teach the mock what the API refuses
before walking the block from one issuer to two and back and away. The hook runs
on the merged object, so it sees the state a request would leave behind, and it
is registered from init() so it covers every deployment update in the package.

It enforces three things. Two are the API's: a change must not leave the
deployment holding both fields, and the list has a minimum length so removal is
an explicit null rather than []. The third is this provider's own contract --
that it writes the list and never the singular field -- because the API would
accept a lone singular value, so nothing else would notice a regression to
writing it.

The minimum-length rule is belt and braces. Removal takes the nil path and Go
marshals a nil slice to null unaided, so the rule only fires for a non-nil empty
slice; the property itself is covered by
TestUpdateDeploymentInput_OidcProvidersMarshaling. It is kept so the mock
mirrors the API rather than only what the provider reaches today.

acc_tests/deployment_oidc_providers_test.go: manufacture a deployment holding
the singular field with a create hook, and migrate it. That state is the only
one in which failing to clear the singular field is observable, and this
provider never writes it, so no test could reach it otherwise -- deleting the
clear from deploymentUpdate passes every other test in the suite and fails this
one with the API's own "not both". It also gives the migration, the most
consequential behaviour here, its first end-to-end test.

acc_tests/deployment_oidc_providers_test.go: refuse the same issuer twice in a
plan step, so the CustomizeDiff check is exercised rather than only described.

Behaviour changes worth stating:

- A deployment created through this provider is stored in the API's list field
  from the start; one that predates this change moves there the first time its
  blocks change, and its singular field is cleared. Authentication is
  unaffected, because the API reads whichever field is set, but a consumer that
  reads the singular field specifically will find it empty where it used to hold
  a value.
- Downgrading the provider afterwards does not work. An earlier version reads no
  issuers from such a deployment, plans to add oidc_provider, and is refused with
  "not both" on apply. Rolling a provider version back, or a colleague still on
  the previous one, meets that.
- expandOidcProviders skips a nil block entry and keeps the rest, where the
  singular version treated a nil first entry as no block at all. Reachable only
  through a malformed configuration, and an all-nil list still yields nothing to
  send.

CHANGELOG.md: seal the entry as 1.22.0. A backward-compatible capability on an
existing block, so a minor bump over 1.21.0, with the link definition the
version headers all carry.

